### PR TITLE
fix: resolve mypy type checking errors and improve type safety

### DIFF
--- a/src/s2dm/cli.py
+++ b/src/s2dm/cli.py
@@ -9,7 +9,11 @@ from s2dm.exporters.shacl import translate_to_shacl
 from s2dm.exporters.vspec import translate_to_vspec
 
 schema_option = click.option(
-    "--schema", "-s", type=click.Path(exists=True), required=True, help="The GraphQL schema file"
+    "--schema",
+    "-s",
+    type=click.Path(exists=True),
+    required=True,
+    help="The GraphQL schema file",
 )
 
 output_option = click.option(
@@ -30,7 +34,11 @@ output_option = click.option(
     help="Log level",
     show_default=True,
 )
-@click.option("--log-file", type=click.Path(dir_okay=False, writable=True, path_type=Path), help="Log file")
+@click.option(
+    "--log-file",
+    type=click.Path(dir_okay=False, writable=True, path_type=Path),
+    help="Log file",
+)
 @click.version_option(__version__)
 def cli(log_level: str, log_file: Path | None) -> None:
     console_handler = logging.StreamHandler()
@@ -49,7 +57,7 @@ def cli(log_level: str, log_file: Path | None) -> None:
 
 
 @click.group()
-def export():
+def export() -> None:
     """Export commands."""
     pass
 
@@ -108,7 +116,11 @@ def shacl(
 ) -> None:
     """Generate SHACL shapes from a given GraphQL schema."""
     result = translate_to_shacl(
-        schema, shapes_namespace, shapes_namespace_prefix, model_namespace, model_namespace_prefix
+        schema,
+        shapes_namespace,
+        shapes_namespace_prefix,
+        model_namespace,
+        model_namespace_prefix,
     )
     _ = result.serialize(destination=output, format=serialization_format)
 

--- a/src/s2dm/concept/models.py
+++ b/src/s2dm/concept/models.py
@@ -1,15 +1,31 @@
 from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any, Generic, TypeVar
+from typing import Any, Generic, Protocol, TypeVar
 
 from pydantic import BaseModel, field_validator
 
-NodeType = TypeVar("NodeType", bound="ConceptBaseModel")
+
+class HasId(Protocol):
+    """Protocol for objects that have an id attribute."""
+
+    id: str
+
+
+NodeType = TypeVar("NodeType", bound=HasId)
 
 
 @dataclass
 class Concepts:
+    """Data class containing all the concepts extracted from a GraphQL schema.
+
+    Args:
+        fields: List of field names
+        enums: List of enum names
+        objects: Dictionary mapping object names to their field lists
+        nested_objects: Dictionary mapping field names to object type names
+    """
+
     fields: list[str] = field(default_factory=list)
     enums: list[str] = field(default_factory=list)
     objects: dict[str, list[str]] = field(default_factory=lambda: defaultdict(list))
@@ -28,7 +44,7 @@ class JsonLDSerializable(BaseModel):
         ),
     }
 
-    def to_json_ld(self) -> dict[str, str]:
+    def to_json_ld(self) -> dict[str, Any]:
         """Serialize model to JSON-LD format with consistent options.
 
         This is the preferred method to use when serializing any model
@@ -59,25 +75,48 @@ class JsonLDSerializable(BaseModel):
 
 # Concept models
 class ConceptBaseModel(JsonLDSerializable, Generic[NodeType]):
-    """A base model for concepts."""
+    """A base model for concepts.
+
+    Args:
+        context: JSON-LD context dictionary
+        graph: List of nodes in the graph
+    """
 
     context: dict[str, Any]
     graph: list[NodeType]
 
     def get_node_by_id(self, node_id: str) -> NodeType | None:
-        """Get a node by its ID."""
+        """Get a node by its ID.
+
+        Args:
+            node_id: The ID of the node to find
+
+        Returns:
+            The node with the given ID, or None if not found
+        """
         for node in self.graph:
             if node.id == node_id:
                 return node
         return None
 
     def get_concept_map(self) -> dict[str, NodeType]:
-        """Create a map of node IDs to nodes."""
+        """Create a map of node IDs to nodes.
+
+        Returns:
+            Dictionary mapping node IDs to node objects
+        """
         return {node.id: node for node in self.graph}
 
 
 class ConceptUriNode(JsonLDSerializable):
-    """A node in the concept URI graph."""
+    """A node in the concept URI graph.
+
+    Args:
+        id: The unique identifier for this node
+        type: The type of the node (Object, Field, Enum, etc.)
+        hasField: List of field IDs for object nodes
+        hasNestedObject: ID of nested object for field nodes
+    """
 
     id: str
     type: str
@@ -85,25 +124,42 @@ class ConceptUriNode(JsonLDSerializable):
     hasNestedObject: str | None = None
 
     def get_concept_name(self) -> str:
-        """Extract the concept name from the URI."""
+        """Extract the concept name from the URI.
+
+        Returns:
+            The concept name (last part after the colon)
+        """
         return self.id.split(":")[-1]
 
     def is_field(self) -> bool:
-        """Check if this node is a Field type."""
+        """Check if this node is a Field type.
+
+        Returns:
+            True if the node type is "Field"
+        """
         return self.type == "Field"
 
     def should_have_history(self) -> bool:
-        """Check if this node should have history (Field or Enum)."""
+        """Check if this node should have history (Field or Enum).
+
+        Returns:
+            True if the node type is "Field" or "Enum"
+        """
         return self.type in ("Field", "Enum")
 
 
 class ConceptUriModel(ConceptBaseModel[ConceptUriNode]):
-    """The core concept URI model."""
+    """The core concept URI model containing concept URI nodes."""
 
 
 # Spec History models
 class SpecHistoryEntry(JsonLDSerializable):
-    """A single entry in the spec history."""
+    """A single entry in the spec history.
+
+    Args:
+        id: The ID value for this history entry
+        timestamp: ISO format timestamp when this entry was created
+    """
 
     id: str
     timestamp: str
@@ -111,7 +167,17 @@ class SpecHistoryEntry(JsonLDSerializable):
     @field_validator("timestamp")
     @classmethod
     def validate_timestamp(cls, v: str) -> str:
-        """Validate that the timestamp is in ISO format."""
+        """Validate that the timestamp is in ISO format.
+
+        Args:
+            v: The timestamp string to validate
+
+        Returns:
+            The validated timestamp string
+
+        Raises:
+            ValueError: If timestamp is not in ISO format
+        """
         try:
             datetime.fromisoformat(v)
         except ValueError as err:
@@ -120,22 +186,40 @@ class SpecHistoryEntry(JsonLDSerializable):
 
     @classmethod
     def create(cls, id_value: str) -> "SpecHistoryEntry":
-        """Create a new spec history entry with the current timestamp."""
+        """Create a new spec history entry with the current timestamp.
+
+        Args:
+            id_value: The ID value for this entry
+
+        Returns:
+            A new SpecHistoryEntry with current timestamp
+        """
         return cls(id=id_value, timestamp=datetime.now().isoformat())
 
 
 class SpecHistoryNode(ConceptUriNode):
-    """A node in the spec history graph with history information."""
+    """A node in the spec history graph with history information.
+
+    Args:
+        specHistory: List of history entries for this node
+    """
 
     specHistory: list[SpecHistoryEntry] | None = None
 
     def initialize_history(self, id_value: str) -> None:
-        """Initialize the spec history with the given ID."""
+        """Initialize the spec history with the given ID.
+
+        Args:
+            id_value: The initial ID value for the history
+        """
         if self.should_have_history():
             self.specHistory = [SpecHistoryEntry.create(id_value)]
 
     def add_history_entry(self, id_value: str) -> bool:
         """Add a new entry to the spec history if it's different from the latest one.
+
+        Args:
+            id_value: The new ID value to add
 
         Returns:
             bool: True if a new entry was added, False otherwise.

--- a/src/s2dm/concept/services.py
+++ b/src/s2dm/concept/services.py
@@ -15,12 +15,35 @@ from s2dm.concept.models import (
 )
 
 
-def load_json_file(file_path: Path) -> dict:
+def load_json_file(file_path: Path) -> dict[str, Any]:
+    """Load a JSON file and return its contents.
+
+    Args:
+        file_path: Path to the JSON file to load
+
+    Returns:
+        Dictionary containing the JSON file contents
+
+    Raises:
+        ValueError: If the loaded content is not a dictionary
+    """
     with open(file_path) as f:
-        return json.load(f)
+        data = json.load(f)
+
+    # Ensure the loaded data is a dictionary
+    if not isinstance(data, dict):
+        raise ValueError(f"Expected JSON object in {file_path}, got {type(data).__name__}")
+
+    return data
 
 
 def save_spec_history(spec_history: SpecHistoryModel, file_path: Path) -> None:
+    """Save a spec history model to a JSON-LD file.
+
+    Args:
+        spec_history: The spec history model to save
+        file_path: Path where to save the file
+    """
     with open(file_path, "w") as f:
         # Use by_alias=True to ensure proper JSON-LD attribute names (@id, @type, etc.)
         json.dump(spec_history.to_json_ld(), f, indent=2)
@@ -104,6 +127,7 @@ def update_spec_history_from_concept_uris(
     """Update this spec history from concept URIs and IDs.
 
     Args:
+        spec_history: The spec history to update
         concept_uris: The concept URIs model
         concept_ids: The concept IDs
 
@@ -236,7 +260,15 @@ def generate_concept_uri(
     return f"{prefix}:{name}"
 
 
-def iter_all_concepts(named_types: list[GraphQLNamedType]):
+def iter_all_concepts(named_types: list[GraphQLNamedType]) -> Concepts:
+    """Extract all concepts from GraphQL named types.
+
+    Args:
+        named_types: List of GraphQL named types to process
+
+    Returns:
+        Concepts object containing all extracted concepts
+    """
     concepts = Concepts()
     for named_type in named_types:
         if named_type.name in ("Query", "Mutation"):
@@ -263,7 +295,9 @@ def iter_all_concepts(named_types: list[GraphQLNamedType]):
                     internal_type = field.type
                     while hasattr(internal_type, "of_type"):
                         internal_type = internal_type.of_type
-                    concepts.nested_objects[field_fqn] = internal_type.name
+                    # Get the name from the internal type if it has one
+                    if hasattr(internal_type, "name"):
+                        concepts.nested_objects[field_fqn] = internal_type.name
                 else:
                     # field uses a scalar type or enum type
                     concepts.objects[named_type.name].append(field_fqn)

--- a/src/s2dm/exporters/concept_uri.py
+++ b/src/s2dm/exporters/concept_uri.py
@@ -32,11 +32,17 @@ def main(
     output: Path | None,
     namespace: str,
     prefix: str,
-):
+) -> None:
     """Generate concept URIs for a GraphQL schema.
 
     The script will generate concept URIs for all objects, fields, and enums in the schema,
     excluding cross-references and ID fields. The URIs will be output in JSON-LD format.
+
+    Args:
+        schema: Path to the GraphQL schema file
+        output: Optional output file path
+        namespace: The namespace for the URIs
+        prefix: The prefix to use for the URIs
     """
     logging.info(f"Processing schema '{schema}'")
 

--- a/src/s2dm/exporters/id.py
+++ b/src/s2dm/exporters/id.py
@@ -65,8 +65,8 @@ def iter_all_id_specs(
                     unit_lookup=unit_lookup,
                 )
 
-                # Only yield realization fields
-                if id_spec.is_realization():
+                # Only yield leaf fields
+                if id_spec.is_leaf_field():
                     yield id_spec
 
 
@@ -80,7 +80,22 @@ def iter_all_id_specs(
 )
 @click.option("--strict-mode/--no-strict-mode", default=False)
 @click.option("--dry-run/--no-dry-run", default=False)
-def main(schema: Path, units_file: Path, output: Path, strict_mode: bool, dry_run: bool):
+def main(
+    schema: Path,
+    units_file: Path,
+    output: Path | None,
+    strict_mode: bool,
+    dry_run: bool,
+) -> None:
+    """Generate IDs for GraphQL schema fields and enums.
+
+    Args:
+        schema: Path to the GraphQL schema file
+        units_file: Path to the units YAML file
+        output: Optional output file path
+        strict_mode: Whether to use strict mode for ID generation
+        dry_run: Whether to perform a dry run without writing files
+    """
     log.info(f"Using units file '{units_file}', input is '{schema}', and output is '{output}'")
 
     # Pass the schema content to build_schema
@@ -105,7 +120,7 @@ def main(schema: Path, units_file: Path, output: Path, strict_mode: bool, dry_ru
         log.debug(f"Type path: {id_spec.name} -> {id_spec.data_type} -> {generated_id}")
 
     # Write the schema to the output file
-    if not dry_run and output:
+    if not dry_run and output is not None:
         with open(output, "w", encoding="utf-8") as output_file:
             log.info(f"Writing data to '{output}'")
             json.dump(node_ids, output_file, indent=2)

--- a/src/s2dm/exporters/spec_history.py
+++ b/src/s2dm/exporters/spec_history.py
@@ -203,8 +203,12 @@ def main(
         # Initialize a new spec history
         log.info(f"Initializing new spec history from {concept_uri} and {ids}")
         result = convert_concept_uri_to_spec_history(concept_uri_model, concept_ids)
-        save_spec_history(result, output)
-        log.info(f"Spec history initialized and saved to {output}")
+
+        if output:
+            save_spec_history(result, output)
+            log.info(f"Spec history initialized and saved to {output}")
+        else:
+            print(result.model_dump(by_alias=True))
 
         # Save type definitions for all concepts if schema is provided
         process_type_definitions(list(concept_ids.keys()), [], concept_ids, schema, history_dir)

--- a/src/s2dm/idgen/README.md
+++ b/src/s2dm/idgen/README.md
@@ -83,8 +83,6 @@ We decided to use the GraphQL type name directly as the fully qualified name (FQ
 - It simplifies the resolution process
 - It maintains consistency with GraphQL's type system
 
-For more details on this decision, see [Issue #32](https://atc-github.azure.cloud.bmw/q555872/s2dm/issues/32).
-
 ## Usage
 
 ```python
@@ -181,4 +179,3 @@ LOG_LEVEL=debug uv run python src/tools/to_id.py -o output.json test.graphql uni
 ## References
 
 - [COVESA VSS Tools ID Documentation](https://github.com/COVESA/vss-tools/blob/master/docs/id.md)
-- [Issue #32: ID Generation Design](https://atc-github.azure.cloud.bmw/q555872/s2dm/issues/32)

--- a/src/s2dm/idgen/models.py
+++ b/src/s2dm/idgen/models.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Any
 
 from graphql import (
     GraphQLArgument,
@@ -11,19 +12,41 @@ from graphql import (
 )
 
 from s2dm import log
-from s2dm.tools.utils import get_directive_arguments, has_directive
+from s2dm.exporters.utils import get_directive_arguments, has_directive
 
 
 class FieldTypeWrapper:
-    def __init__(self, field_type: GraphQLType):
+    """Wrapper for GraphQL field types to provide consistent interface.
+
+    Args:
+        field_type: The GraphQL type to wrap
+    """
+
+    def __init__(self, field_type: GraphQLType) -> None:
         self._field_type = field_type
 
     @property
     def name(self) -> str:
-        return self._field_type.name
+        """Get the name of the GraphQL type.
+
+        Returns:
+            The name of the type
+
+        Raises:
+            AttributeError: If the type does not have a name attribute
+        """
+        if not hasattr(self._field_type, "name"):
+            raise AttributeError(f"GraphQL type {type(self._field_type).__name__} has no 'name' attribute")
+        # Cast to str to satisfy mypy since we've verified the attribute exists
+        return str(self._field_type.name)
 
     @property
     def internal_type(self) -> "FieldTypeWrapper":
+        """Get the internal type by unwrapping list and non-null wrappers.
+
+        Returns:
+            A FieldTypeWrapper containing the internal type
+        """
         internal_type = self._field_type
         if self.is_list_type():
             # Unwrap non-null and list types
@@ -32,33 +55,61 @@ class FieldTypeWrapper:
         return FieldTypeWrapper(internal_type)
 
     def get_allowed_enum_values(self) -> str:
-        if self.is_enum_type():
-            return str(sorted(list(self._field_type.values.keys())))
-        return ""
+        """Get allowed enum values as a string.
+
+        Returns:
+            String representation of sorted enum values, or empty string if not an enum
+        """
+        if not self.is_enum_type() or not hasattr(self._field_type, "values"):
+            return ""
+
+        return str(sorted(list(self._field_type.values.keys())))
 
     def is_enum_type(self) -> bool:
+        """Check if this is an enum type.
+
+        Returns:
+            True if this is a GraphQL enum type
+        """
         return isinstance(self._field_type, GraphQLEnumType)
 
     def is_scalar_type(self) -> bool:
+        """Check if this is a scalar type.
+
+        Returns:
+            True if this is a GraphQL scalar type
+        """
         return isinstance(self._field_type, GraphQLScalarType)
 
     def is_list_type(self) -> bool:
+        """Check if this is a list type.
+
+        Returns:
+            True if this is a GraphQL list type
+        """
         return isinstance(self._field_type, GraphQLList)
 
     def is_object_type(self) -> bool:
+        """Check if this is an object type.
+
+        Returns:
+            True if this is a GraphQL object type
+        """
         return isinstance(self._field_type, GraphQLObjectType)
 
 
 @dataclass(frozen=True)
 class IDGenerationSpec:
-    """Collection of fields and methods required for ID generation
-    @param name: fully qualified name of the field
-    @param data_type: datatype of the field: string, int, float, boolean, uint8 etc.
-    @param unit: unit of the field if exists
-    @param allowed: the enum for allowed values
-    @param minimum: min value for the data if exists
-    @param maximum: max value for the data if exists
-    @param _field_type: the field type
+    """Collection of fields and methods required for ID generation.
+
+    Args:
+        name: fully qualified name of the field
+        data_type: datatype of the field: string, int, float, boolean, uint8 etc.
+        unit: unit of the field if exists
+        allowed: the enum for allowed values
+        minimum: min value for the data if exists
+        maximum: max value for the data if exists
+        _field_type: the field type
     """
 
     name: str
@@ -71,7 +122,17 @@ class IDGenerationSpec:
     # Internal fields
     _field_type: FieldTypeWrapper | None = None
 
-    def __eq__(self, other: "IDGenerationSpec") -> bool:
+    def __eq__(self, other: object) -> bool:
+        """Check equality with another IDGenerationSpec.
+
+        Args:
+            other: The object to compare with
+
+        Returns:
+            True if objects are equal, False otherwise
+        """
+        if not isinstance(other, IDGenerationSpec):
+            return NotImplemented
         return (
             self.name == other.name
             and self.data_type == other.data_type
@@ -82,22 +143,45 @@ class IDGenerationSpec:
         )
 
     def __hash__(self) -> int:
+        """Generate hash for the IDGenerationSpec.
+
+        Returns:
+            Hash value for this instance
+        """
         return hash(f"{self.name}:{self.data_type}:{self.unit}:{self.allowed}:{self.minimum}:{self.maximum}")
 
-    def is_concept(self):
+    def is_object_type(self) -> bool:
+        """Check if this field is an object type.
+
+        Returns:
+            True if this field is an object type
+
+        Raises:
+            AttributeError: If _field_type is None
+        """
+        if self._field_type is None:
+            raise AttributeError("_field_type is None")
         return self._field_type.internal_type.is_object_type()
 
-    def is_realization(self):
-        return not self.is_concept()
+    def is_leaf_field(self) -> bool:
+        """Check if this field is a leaf field.
+
+        Returns:
+            True if this field is a leaf field
+        """
+        return not self.is_object_type()
 
     def get_node_identifier_bytes(
         self,
         strict_mode: bool,
     ) -> bytes:
-        """Get a node identifier as bytes. Used as an input for hashing
+        """Get a node identifier as bytes. Used as an input for hashing.
 
-        @param strict_mode: strict mode means case sensitivity of node qualified names
-        @return: a bytes representation of the node
+        Args:
+            strict_mode: strict mode means case sensitivity of node qualified names
+
+        Returns:
+            a bytes representation of the node
         """
 
         node_identifier: bytes = (
@@ -122,6 +206,17 @@ class IDGenerationSpec:
         *,
         field: GraphQLEnumType,
     ) -> "IDGenerationSpec":
+        """Create an IDGenerationSpec from a GraphQL enum type.
+
+        Args:
+            field: The GraphQL enum type
+
+        Returns:
+            An IDGenerationSpec for the enum
+
+        Raises:
+            ValueError: If field is not a GraphQLEnumType
+        """
         if not isinstance(field, GraphQLEnumType):
             raise ValueError(f"Field is not a GraphQLEnumType: {field}")
 
@@ -144,12 +239,19 @@ class IDGenerationSpec:
         field: GraphQLField,
         unit_lookup: dict[str, str],
     ) -> "IDGenerationSpec":
-        """Create an IDGenerationSpec from a GraphQL field
+        """Create an IDGenerationSpec from a GraphQL field.
 
-        @param parent_name: Parent name of the field
-        @param field_name: the name of the field
-        @param field: the GraphQL field to extract the ID generation spec from
-        @return: an IDGenerationSpec
+        Args:
+            parent_name: Parent name of the field
+            field_name: the name of the field
+            field: the GraphQL field to extract the ID generation spec from
+            unit_lookup: Dictionary mapping unit names to unit values
+
+        Returns:
+            an IDGenerationSpec
+
+        Raises:
+            ValueError: If field is not a GraphQLField
         """
 
         if not isinstance(field, GraphQLField):
@@ -189,11 +291,15 @@ class IDGenerationSpec:
 
     @staticmethod
     def _resolve_data_type(original_field_type: FieldTypeWrapper) -> str:
-        """Resolve the data type from original and inside field types
+        """Resolve the data type from original and inside field types.
+
         If the original field type is a list, wrap the inside field type with "list[]"
-        @param original_field_type: the original field type
-        @param inside_field_type: the inside field type
-        @return: the data type
+
+        Args:
+            original_field_type: the original field type
+
+        Returns:
+            the data type
         """
 
         internal_field_type = original_field_type.internal_type
@@ -208,16 +314,39 @@ class IDGenerationSpec:
         surrounding_type = original_field_type
         while surrounding_type.is_list_type():
             field_type_name = f"{field_type_name}[]"
-            surrounding_type = FieldTypeWrapper(surrounding_type._field_type.of_type)
+            if hasattr(surrounding_type._field_type, "of_type"):
+                surrounding_type = FieldTypeWrapper(surrounding_type._field_type.of_type)
+            else:
+                break
 
         return field_type_name
 
     @staticmethod
     def _resolve_allowed(field: FieldTypeWrapper) -> str:
+        """Resolve allowed enum values from a field type.
+
+        Args:
+            field: The field type wrapper
+
+        Returns:
+            String representation of allowed values
+        """
         return field.get_allowed_enum_values()
 
     @staticmethod
-    def _resolve_unit(field_args: dict, unit_lookup: dict[str, str]) -> str:
+    def _resolve_unit(field_args: dict[str, GraphQLArgument], unit_lookup: dict[str, str]) -> str:
+        """Resolve unit from field arguments.
+
+        Args:
+            field_args: Dictionary of field arguments
+            unit_lookup: Dictionary mapping unit names to unit values
+
+        Returns:
+            The resolved unit string
+
+        Raises:
+            KeyError: If the unit is not found in the unit lookup
+        """
         unit = field_args.get("unit", "")
         if unit and isinstance(unit, GraphQLArgument):
             unit = unit.default_value
@@ -229,20 +358,53 @@ class IDGenerationSpec:
         parent_name: str,
         field_name: str,
     ) -> str:
+        """Resolve the fully qualified name from parent and field names.
+
+        Args:
+            parent_name: The parent type name
+            field_name: The field name
+
+        Returns:
+            The fully qualified name
+        """
         return f"{parent_name}.{field_name}"
 
     @staticmethod
     def _resolve_range(
         field: GraphQLField,
-    ) -> dict[str, int | float | None]:
+    ) -> dict[str, Any]:
+        """Resolve range directive from a GraphQL field.
+
+        Args:
+            field: The GraphQL field
+
+        Returns:
+            Dictionary with range values or empty dict if no range directive
+        """
         if has_directive(field, "range"):
             return get_directive_arguments(field, "range")
         return {}
 
     @staticmethod
     def _resolve_minimum(field: GraphQLField) -> int | float | None:
+        """Resolve minimum value from range directive.
+
+        Args:
+            field: The GraphQL field
+
+        Returns:
+            The minimum value or None if not specified
+        """
         return IDGenerationSpec._resolve_range(field).get("min")
 
     @staticmethod
     def _resolve_maximum(field: GraphQLField) -> int | float | None:
+        """Resolve maximum value from range directive.
+
+        Args:
+            field: The GraphQL field
+
+        Returns:
+            The maximum value or None if not specified
+        """
         return IDGenerationSpec._resolve_range(field).get("max")


### PR DESCRIPTION
- Fix generic type issues in concept models using Protocol instead of circular bounds
- Add proper GraphQL type handling with attribute checking and casting
- Fix return type annotations in exporters and add Path null checks
- Improve JSON loading with runtime type validation
- Add comprehensive type annotations and docstrings following PEP 257
- Fix import paths and method signatures