### PR TITLE
ci: add automatic semantic versioning

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "0.1.0"
+current_version = "0.2.0"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 search = "{current_version}"

--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,0 +1,18 @@
+[tool.bumpversion]
+current_version = "0.1.0"
+parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
+serialize = ["{major}.{minor}.{patch}"]
+search = "{current_version}"
+replace = "{new_version}"
+regex = false
+ignore_missing_version = false
+ignore_missing_files = false
+tag = true
+sign_tags = false
+tag_name = "v{new_version}"
+tag_message = "Bump version: {current_version} → {new_version}"
+allow_dirty = false
+commit = true
+message = "chore: bump version {current_version} → {new_version}"
+moveable_tags = []
+commit_args = ""

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,118 @@
+name: release
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: setup python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: sync
+        run: uv sync
+
+      - name: install git-cliff
+        run: |
+          curl -L https://github.com/orhun/git-cliff/releases/download/v2.9.1/git-cliff-2.9.1-x86_64-unknown-linux-gnu.tar.gz | tar xz
+          sudo mv git-cliff-2.9.1/git-cliff /usr/local/bin/
+
+      - name: determine version bump
+        id: version
+        run: |
+          # Get commits since last tag
+          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          if [ -z "$LAST_TAG" ]; then
+            COMMITS=$(git log --pretty=format:"%s" HEAD)
+          else
+            COMMITS=$(git log --pretty=format:"%s" ${LAST_TAG}..HEAD)
+          fi
+
+          echo "Commits since last tag:"
+          echo "$COMMITS"
+
+          # Determine version bump based on conventional commits
+          MAJOR=false
+          MINOR=false
+          PATCH=false
+
+          while IFS= read -r commit; do
+            echo "Analyzing: $commit"
+            if echo "$commit" | grep -qE "^[a-zA-Z]+(\(.+\))?!:"; then
+              echo "Breaking change detected"
+              MAJOR=true
+            elif echo "$commit" | grep -qE "^feat(\(.+\))?:"; then
+              echo "Feature detected"
+              MINOR=true
+            elif echo "$commit" | grep -qE "^(fix|perf)(\(.+\))?:"; then
+              echo "Fix/perf detected"
+              PATCH=true
+            elif echo "$commit" | grep -qE "BREAKING CHANGE:"; then
+              echo "Breaking change in body detected"
+              MAJOR=true
+            fi
+          done <<< "$COMMITS"
+
+          # Determine bump type (major > minor > patch)
+          if [ "$MAJOR" = true ]; then
+            echo "bump=major" >> $GITHUB_OUTPUT
+            echo "Version bump: MAJOR"
+          elif [ "$MINOR" = true ]; then
+            echo "bump=minor" >> $GITHUB_OUTPUT
+            echo "Version bump: MINOR"
+          elif [ "$PATCH" = true ]; then
+            echo "bump=patch" >> $GITHUB_OUTPUT
+            echo "Version bump: PATCH"
+          else
+            echo "bump=none" >> $GITHUB_OUTPUT
+            echo "No version bump needed"
+          fi
+
+      - name: bump version
+        if: steps.version.outputs.bump != 'none'
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          uv run bump-my-version bump ${{ steps.version.outputs.bump }}
+
+      - name: push changes
+        if: steps.version.outputs.bump != 'none'
+        run: |
+          git push origin ${{ github.ref_name }} --tags
+
+      - name: create release
+        if: steps.version.outputs.bump != 'none'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Get the new version
+          NEW_VERSION=$(git describe --tags --abbrev=0)
+
+          # Generate changelog with git-cliff
+          LAST_TAG=$(git tag --sort=-version:refname | sed -n '2p')
+          if [ -z "$LAST_TAG" ]; then
+            CHANGELOG=$(git-cliff --latest --strip=header)
+          else
+            CHANGELOG=$(git-cliff ${LAST_TAG}..${NEW_VERSION} --strip=header)
+          fi
+
+          # Create GitHub release
+          gh release create ${NEW_VERSION} \
+            --title "Release ${NEW_VERSION}" \
+            --notes "## Changes
+
+          ${CHANGELOG}"

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,54 @@
+[changelog]
+header = """
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+"""
+body = """
+{% if version %}\
+    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+    ## [unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+    ### {{ group | striptags | trim | upper_first }}
+    {% for commit in commits %}
+        - {% if commit.scope %}**{{ commit.scope }}**: {% endif %}{{ commit.message | upper_first }}
+    {%- endfor %}
+{% endfor %}\n
+"""
+trim = true
+
+[git]
+conventional_commits = true
+filter_unconventional = false
+split_commits = false
+commit_preprocessors = [
+    { pattern = '\((\w+\s)?#([0-9]+)\)', replace = "([#${2}](https://github.com/COVESA/s2dm/pull/${2}))" },
+]
+commit_parsers = [
+    { message = "^feat", group = "<!-- 0 -->🚀 Features" },
+    { message = "^fix", group = "<!-- 1 -->🐛 Bug Fixes" },
+    { message = "^doc", group = "<!-- 3 -->📚 Documentation" },
+    { message = "^perf", group = "<!-- 4 -->⚡ Performance" },
+    { message = "^refactor", group = "<!-- 2 -->🚜 Refactor" },
+    { message = "^style", group = "<!-- 5 -->🎨 Styling" },
+    { message = "^test", group = "<!-- 6 -->🧪 Testing" },
+    { message = "^chore\\(release\\): prepare for", skip = true },
+    { message = "^chore\\(deps.*\\)", skip = true },
+    { message = "^chore\\(pr\\)", skip = true },
+    { message = "^chore\\(pull\\)", skip = true },
+    { message = "^chore|^ci", group = "<!-- 7 -->⚙️ Miscellaneous Tasks" },
+    { body = ".*security", group = "<!-- 8 -->🛡️ Security" },
+    { message = "^revert", group = "<!-- 9 -->◀️ Revert" },
+]
+protect_breaking_commits = false
+filter_commits = false
+tag_pattern = "v[0-9].*"
+skip_tags = "v0.1.0-beta.1"
+ignore_tags = ""
+topo_order = false
+sort_commits = "oldest"


### PR DESCRIPTION
hi everyone,

this is a first draft for the automatic version bumps in s2dm, are there any strong opinions on how this should work? It currently uses bump-my-version for version bumps, git-cliff to create the CHANGELOG, and gh cli to create a release. I personally like git-cliff to create the CHANGELOG but I am very open for any better suggestions or best practices

any input here is highly appreciated


Edit: I merged this to develop to run the release pipeline as a test and it seems to be working properly the generated output can temporarily be reviewed here https://github.com/COVESA/s2dm/releases/tag/v0.2.0

Also please squash all commits here when done reviewing