### PR TITLE
feat: enhance version-bump command to allow automated semantic versioning

### DIFF
--- a/docs-gen/content/3-examples/_index.md
+++ b/docs-gen/content/3-examples/_index.md
@@ -13,4 +13,8 @@ Below are some examples of how the Simplified Semantic Data Modeling (`S2DM`) ap
 - [Seat to VSS Mapping](https://github.com/COVESA/s2dm/tree/main/examples/seat-to-vspec): Mapping modular seat specifications to the Vehicle Signal Specification (VSS).
 - [Specification History Registry](https://github.com/COVESA/s2dm/tree/main/examples/spec-history-registry): Tracking changes and maintaining a registry of specification history.
 
+## CLI Tool Examples
+
+- [Version Bump CLI Examples](version-bump-cli): Demonstrating automated version bumping based on GraphQL schema changes using the `s2dm check version-bump` command.
+
 > If your use case is not covered by the presented examples, feel free to get in touch. If this approach suits your use case, we will add it here.

--- a/docs-gen/content/3-examples/version-bump-cli.md
+++ b/docs-gen/content/3-examples/version-bump-cli.md
@@ -1,0 +1,175 @@
+---
+title: Version Bump CLI Examples
+weight: 60
+---
+
+This section contains examples demonstrating different scenarios for the `s2dm check version-bump` command, based on GraphQL Inspector's change detection.
+
+## Overview
+
+The version-bump command analyzes GraphQL schema changes and recommends the appropriate semantic version bump:
+
+- **No version bump**: Identical schemas
+- **Patch/Minor bump**: Non-breaking changes (new optional fields, enum values)
+- **Major bump**: Breaking changes (removed fields, type changes)
+- **Dangerous changes**: Potentially problematic but not immediately breaking
+
+## Examples
+
+### 1. No Version Bump Needed
+
+**Command:**
+
+```bash
+s2dm check version-bump -s no-change.graphql -p base.graphql
+```
+
+**Expected Output:**
+
+```bash
+No version bump needed
+```
+
+**Scenario:** Both schemas are identical, no changes detected.
+
+### 2. Non-Breaking Change (Minor/Patch Bump)
+
+**Command:**
+
+```bash
+s2dm check version-bump -s non-breaking.graphql -p base.graphql
+```
+
+**Expected Output:**
+
+```bash
+Patch version bump needed
+```
+
+**Changes:**
+
+- Added new optional fields: `Vehicle.owner`, `Vehicle.mileage`, `Engine.fuelEfficiency`
+
+These changes are backwards compatible and won't break existing clients.
+
+### 3. Dangerous Change
+
+**Command:**
+
+```bash
+s2dm check version-bump -s dangerous.graphql -p base.graphql
+```
+
+**Expected Output:**
+
+```bash
+Minor version bump needed
+```
+
+**Changes:**
+
+- Added new enum value: `EngineType.HYDROGEN`
+
+Note: GraphQL Inspector may classify these as dangerous changes depending on configuration, but they're typically backwards compatible due to default values.
+
+### 4. Breaking Change (Major Bump)
+
+**Command:**
+
+```bash
+s2dm check version-bump -s breaking.graphql -p base.graphql
+```
+
+**Expected Output:**
+
+```bash
+Detected breaking changes, major version bump needed. Please run diff to get more details
+```
+
+**Changes:**
+
+- Removed field: `Vehicle.color`
+- Changed field type: `Vehicle.owner` from `String` to `Int`
+- Changed field type: `Engine.displacement` from `Float` to `Int`
+- Removed enum value: `EngineType.HYBRID`
+
+These changes will break existing clients that depend on the removed/changed fields.
+
+## Understanding Change Types
+
+### Non-Breaking Changes ✅
+
+- Adding new optional fields
+- Adding new enum values
+- Adding new types
+- Adding new queries/mutations
+- Adding descriptions/deprecation notices
+
+### Dangerous Changes ⚠️
+
+- Adding arguments to existing fields (with defaults)
+- Changing field descriptions significantly
+- Adding interfaces to existing types
+
+### Breaking Changes ❌
+
+- Removing fields, types, or enum values
+- Changing field types incompatibly
+- Making optional fields required
+- Removing or changing arguments
+- Changing field nullability (nullable to non-nullable)
+
+## Running the Examples
+
+To test these examples:
+
+```bash
+# Navigate to the test data directory
+cd tests/data
+
+# Test each scenario
+s2dm check version-bump -s no-change.graphql -p base.graphql
+s2dm check version-bump -s non-breaking.graphql -p base.graphql
+s2dm check version-bump -s dangerous.graphql -p base.graphql
+s2dm check version-bump -s breaking.graphql -p base.graphql
+```
+
+## Additional Commands
+
+For more detailed analysis, use the diff command:
+
+```bash
+s2dm diff graphql -s breaking.graphql -v base.graphql
+```
+
+This will provide a comprehensive breakdown of all changes detected between the schemas.
+
+## Pipeline Usage
+
+For pipeline automation, use the `--output-type` flag to get machine-readable output:
+
+```bash
+# Returns: none, patch, minor, or major
+VERSION_BUMP=$(s2dm check version-bump -s new-schema.graphql -p old-schema.graphql --output-type)
+
+# Example pipeline usage:
+if [[ "$VERSION_BUMP" == "major" ]]; then
+    echo "Breaking changes detected, requires manual review"
+    exit 1
+elif [[ "$VERSION_BUMP" == "minor" ]]; then
+    echo "Minor version bump needed"
+    # bump-my-version bump minor
+elif [[ "$VERSION_BUMP" == "patch" ]]; then
+    echo "Patch version bump needed"
+    # bump-my-version bump patch
+else
+    echo "No version bump needed"
+fi
+```
+
+## Return Values
+
+- **none**: No changes detected
+- **patch**: Non-breaking changes only (✔ symbols in diff)
+- **minor**: Dangerous changes detected (⚠ symbols in diff)
+- **major**: Breaking changes detected (✖ symbols in diff)

--- a/tests/data/base.graphql
+++ b/tests/data/base.graphql
@@ -1,0 +1,27 @@
+type Query {
+  vehicle: Vehicle
+}
+
+"""Basic vehicle information."""
+type Vehicle {
+  id: ID!
+  brand: String!
+  model: String!
+  year: Int!
+  color: String
+  engine: Engine
+}
+
+"""Engine specifications."""
+type Engine {
+  type: EngineType!
+  displacement: Float
+  horsepower: Int
+}
+
+enum EngineType {
+  GASOLINE
+  DIESEL
+  ELECTRIC
+  HYBRID
+}

--- a/tests/data/breaking.graphql
+++ b/tests/data/breaking.graphql
@@ -1,0 +1,30 @@
+type Query {
+  vehicle: Vehicle
+}
+
+"""Basic vehicle information."""
+type Vehicle {
+  id: ID!
+  brand: String!
+  model: String!
+  year: Int!
+  # Breaking: Removed field 'color'
+  engine: Engine
+  # Breaking: Changed field type from String to Int
+  owner: Int
+}
+
+"""Engine specifications."""
+type Engine {
+  type: EngineType!
+  # Breaking: Changed field type from Float to Int
+  displacement: Int
+  horsepower: Int
+}
+
+enum EngineType {
+  GASOLINE
+  DIESEL
+  ELECTRIC
+  # Breaking: Removed enum value 'HYBRID'
+}

--- a/tests/data/dangerous.graphql
+++ b/tests/data/dangerous.graphql
@@ -1,0 +1,31 @@
+type Query {
+  vehicle: Vehicle
+}
+
+"""Basic vehicle information."""
+type Vehicle {
+  id: ID!
+  brand: String!
+  model: String!
+  year: Int!
+  color: String
+  engine: Engine
+  # Dangerous: Added argument to existing field
+  owner(includeHistory: Boolean = false): String
+}
+
+"""Engine specifications."""
+type Engine {
+  type: EngineType!
+  displacement: Float
+  horsepower: Int
+}
+
+enum EngineType {
+  GASOLINE
+  DIESEL
+  ELECTRIC
+  HYBRID
+  # Dangerous: Added new enum value
+  HYDROGEN
+}

--- a/tests/data/no-change.graphql
+++ b/tests/data/no-change.graphql
@@ -1,0 +1,27 @@
+type Query {
+  vehicle: Vehicle
+}
+
+"""Basic vehicle information."""
+type Vehicle {
+  id: ID!
+  brand: String!
+  model: String!
+  year: Int!
+  color: String
+  engine: Engine
+}
+
+"""Engine specifications."""
+type Engine {
+  type: EngineType!
+  displacement: Float
+  horsepower: Int
+}
+
+enum EngineType {
+  GASOLINE
+  DIESEL
+  ELECTRIC
+  HYBRID
+}

--- a/tests/data/non-breaking.graphql
+++ b/tests/data/non-breaking.graphql
@@ -1,0 +1,33 @@
+type Query {
+  vehicle: Vehicle
+}
+
+"""Basic vehicle information."""
+type Vehicle {
+  id: ID!
+  brand: String!
+  model: String!
+  year: Int!
+  color: String
+  engine: Engine
+  # Non-breaking: Added new optional field
+  owner: String
+  # Non-breaking: Added new optional field
+  mileage: Int
+}
+
+"""Engine specifications."""
+type Engine {
+  type: EngineType!
+  displacement: Float
+  horsepower: Int
+  # Non-breaking: Added new optional field
+  fuelEfficiency: Float
+}
+
+enum EngineType {
+  GASOLINE
+  DIESEL
+  ELECTRIC
+  HYBRID
+}


### PR DESCRIPTION
  - Enhanced version-bump command to detect semantic version types (patch/minor/major)
  - Added pipeline integration with --output-type flag
  - Comprehensive test coverage and documentation
  - Ready for CI/CD automation workflows

Please see documentation in `docs-gen/content/3-examples/version-bump-cli.md` for more info