### PR TITLE
fix: shacl comment and test graphql field cases.

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -6,7 +6,7 @@ nox.options.default_venv_backend = "uv"
 
 
 @nox.session(python=PYTHON_VERSIONS)
-def tests(session):
+def tests(session: nox.Session) -> None:
     session.run_install(
         "uv",
         "sync",

--- a/src/s2dm/exporters/shacl.py
+++ b/src/s2dm/exporters/shacl.py
@@ -53,6 +53,13 @@ def get_xsd_datatype(scalar: GraphQLScalarType) -> URIRef:
     return XSD[GRAPHQL_SCALAR_TO_XSD[scalar.name]]
 
 
+def add_comment_to_property_node(field: GraphQLField, property_node: BNode, graph: Graph) -> None:
+    """Add comment metadata to a property node if it exists."""
+    comment = get_argument_content(field, "metadata", "comment")
+    if comment and comment != {}:
+        _ = graph.add((property_node, RDFS.comment, Literal(comment)))
+
+
 def translate_to_shacl(
     schema_path: Path,
     shapes_namespace: str,
@@ -142,9 +149,7 @@ def create_property_shape_with_literal(
     if field.description:
         _ = graph.add((property_node, SH.description, Literal(field.description)))
 
-    comment = get_argument_content(field, "metadata", "comment")
-    if comment and comment != {}:
-        _ = graph.add((property_node, RDFS.comment, Literal(comment)))
+    add_comment_to_property_node(field, property_node, graph)
 
 
 def create_property_shape_with_iri(
@@ -173,6 +178,8 @@ def create_property_shape_with_iri(
 
     if field.description:
         _ = graph.add((property_node, SH.description, Literal(field.description)))
+
+    add_comment_to_property_node(field, property_node, graph)
 
 
 def process_field(

--- a/src/s2dm/exporters/utils.py
+++ b/src/s2dm/exporters/utils.py
@@ -15,7 +15,12 @@ from graphql import (
     is_list_type,
     is_non_null_type,
 )
-from graphql.type import GraphQLField, GraphQLNamedType, GraphQLObjectType, GraphQLSchema, GraphQLWrappingType
+from graphql.type import (
+    GraphQLField,
+    GraphQLNamedType,
+    GraphQLObjectType,
+    GraphQLSchema,
+)
 from graphql.utilities import print_schema
 
 from s2dm import log
@@ -283,16 +288,21 @@ def get_field_case(field: GraphQLField) -> FieldCase:
         FieldCase: The case of the field as one of the 6 possible cases that are possible with the GraphQL SDL.
         without custom directives.
     """
-    if is_non_null_type(field.type):
-        if is_list_type(field.type) and isinstance(field.type, GraphQLWrappingType):
-            if is_non_null_type(field.type.of_type) and isinstance(field.type.of_type, GraphQLWrappingType):
+    t = field.type
+
+    if is_non_null_type(t):
+        t = t.of_type  # type: ignore[union-attr]
+        if is_list_type(t):
+            if is_non_null_type(t.of_type):
                 return FieldCase.NON_NULL_LIST_NON_NULL
             return FieldCase.NON_NULL_LIST
         return FieldCase.NON_NULL
-    if is_list_type(field.type):
-        if isinstance(field.type, GraphQLWrappingType) and is_non_null_type(field.type.of_type):
+
+    if is_list_type(t):
+        if is_non_null_type(t.of_type):  # type: ignore[union-attr]
             return FieldCase.LIST_NON_NULL
         return FieldCase.LIST
+
     return FieldCase.DEFAULT
 
 

--- a/tests/test_get_field_case.py
+++ b/tests/test_get_field_case.py
@@ -1,0 +1,142 @@
+"""Tests for get_field_case and get_field_case_extended functions using the test_spec.graphql schema."""
+
+from pathlib import Path
+
+import pytest
+
+from s2dm.exporters.utils import FieldCase, get_field_case, get_field_case_extended, load_schema
+
+
+@pytest.fixture
+def test_schema():  # type: ignore[no-untyped-def]
+    """Load the test schema from test_spec.graphql."""
+    schema_path = Path(__file__).parent / "test_type_modifiers" / "test_spec.graphql"
+    return load_schema(schema_path)
+
+
+@pytest.mark.parametrize(
+    "field_name,expected_case",
+    [
+        # A - DEFAULT cases
+        ("defaultScalar", FieldCase.DEFAULT),
+        ("defaultType", FieldCase.DEFAULT),
+        ("defaultWithInstances", FieldCase.DEFAULT),
+        # B - NON_NULL cases
+        ("nonNullScalar", FieldCase.NON_NULL),
+        ("nonNull", FieldCase.NON_NULL),
+        ("nonNullWithInstances", FieldCase.NON_NULL),
+        # C - LIST cases
+        ("listScalar", FieldCase.LIST),
+        ("list", FieldCase.LIST),
+        ("listWithInstances", FieldCase.LIST),
+        # D - NON_NULL_LIST cases
+        ("nonNullListScalar", FieldCase.NON_NULL_LIST),
+        ("nonNullList", FieldCase.NON_NULL_LIST),
+        ("nonNullListWithInstances", FieldCase.NON_NULL_LIST),
+        # E - LIST_NON_NULL cases
+        ("listNonNullScalar", FieldCase.LIST_NON_NULL),
+        ("listNonNull", FieldCase.LIST_NON_NULL),
+        ("listNonNullWithInstances", FieldCase.LIST_NON_NULL),
+        # F - NON_NULL_LIST_NON_NULL cases
+        ("nonNullListNonNullScalar", FieldCase.NON_NULL_LIST_NON_NULL),
+        ("nonNullListNonNull", FieldCase.NON_NULL_LIST_NON_NULL),
+        ("nonNullListNonNullWithInstances", FieldCase.NON_NULL_LIST_NON_NULL),
+    ],
+)
+def test_get_field_case_basic(test_schema, field_name, expected_case):  # type: ignore[no-untyped-def]
+    """Test get_field_case function with basic GraphQL field types (A-F cases)."""
+    test_type = test_schema.type_map["TestTypeModifiers"]
+    field = test_type.fields[field_name]
+
+    actual_case = get_field_case(field)
+    assert actual_case == expected_case, f"Field '{field_name}' expected {expected_case}, got {actual_case}"
+
+
+@pytest.mark.parametrize(
+    "field_name,expected_case",
+    [
+        # G - SET cases (LIST + @noDuplicates)
+        ("setScalar", FieldCase.SET),
+        ("set", FieldCase.SET),
+        ("setEnum", FieldCase.SET),
+        ("setWithInstances", FieldCase.SET),
+        # H - SET_NON_NULL cases (LIST_NON_NULL + @noDuplicates)
+        ("setNonNullScalar", FieldCase.SET_NON_NULL),
+        ("setNonNull", FieldCase.SET_NON_NULL),
+        ("setNonNullWithInstances", FieldCase.SET_NON_NULL),
+    ],
+)
+def test_get_field_case_extended_with_directives(test_schema, field_name, expected_case):  # type: ignore[no-untyped-def]
+    """Test get_field_case_extended function with custom directive cases (G-H cases)."""
+    test_type = test_schema.type_map["TestTypeModifiers"]
+    field = test_type.fields[field_name]
+
+    actual_case = get_field_case_extended(field)
+    assert actual_case == expected_case, f"Field '{field_name}' expected {expected_case}, got {actual_case}"
+
+
+def test_get_field_case_vs_extended(test_schema):  # type: ignore[no-untyped-def]
+    """Test that get_field_case and get_field_case_extended return different results for directive cases."""
+    test_type = test_schema.type_map["TestTypeModifiers"]
+
+    # Fields with @noDuplicates should differ between basic and extended
+    set_fields = ["setScalar", "set", "setEnum", "setWithInstances"]
+    set_non_null_fields = ["setNonNullScalar", "setNonNull", "setNonNullWithInstances"]
+
+    for field_name in set_fields:
+        field = test_type.fields[field_name]
+        basic_case = get_field_case(field)
+        extended_case = get_field_case_extended(field)
+
+        assert basic_case == FieldCase.LIST
+        assert extended_case == FieldCase.SET
+        assert basic_case != extended_case  # type: ignore[comparison-overlap]
+
+    for field_name in set_non_null_fields:
+        field = test_type.fields[field_name]
+        basic_case = get_field_case(field)
+        extended_case = get_field_case_extended(field)
+
+        assert basic_case == FieldCase.LIST_NON_NULL
+        assert extended_case == FieldCase.SET_NON_NULL
+        assert basic_case != extended_case  # type: ignore[comparison-overlap]
+
+
+def test_all_field_cases_covered(test_schema):  # type: ignore[no-untyped-def]
+    """Test that all FieldCase enum values are represented in the test schema."""
+    test_type = test_schema.type_map["TestTypeModifiers"]
+
+    # Get all field cases from the schema
+    basic_cases = set()
+    extended_cases = set()
+
+    for _field_name, field in test_type.fields.items():
+        basic_cases.add(get_field_case(field))
+        extended_cases.add(get_field_case_extended(field))
+
+    # Check that all FieldCase values are covered
+    all_field_cases = set(FieldCase)
+
+    assert extended_cases == all_field_cases, f"Missing field cases: {all_field_cases - extended_cases}"
+
+
+def test_field_case_consistency(test_schema):  # type: ignore[no-untyped-def]
+    """Test that field case logic is consistent across different output types."""
+    test_type = test_schema.type_map["TestTypeModifiers"]
+
+    # Group fields by their type pattern (e.g., all DEFAULT fields should behave the same)
+    patterns = {
+        "default": ["defaultScalar", "defaultType", "defaultWithInstances"],
+        "nonNull": ["nonNullScalar", "nonNull", "nonNullWithInstances"],
+        "list": ["listScalar", "list", "listWithInstances"],
+        "nonNullList": ["nonNullListScalar", "nonNullList", "nonNullListWithInstances"],
+        "listNonNull": ["listNonNullScalar", "listNonNull", "listNonNullWithInstances"],
+        "nonNullListNonNull": ["nonNullListNonNullScalar", "nonNullListNonNull", "nonNullListNonNullWithInstances"],
+    }
+
+    for pattern_name, field_names in patterns.items():
+        cases = [get_field_case(test_type.fields[fname]) for fname in field_names]
+        # All fields in the same pattern should return the same FieldCase
+        assert len(set(cases)) == 1, (
+            f"Inconsistent field cases for pattern {pattern_name}: " f"{dict(zip(field_names, cases, strict=True))}"
+        )

--- a/tests/test_get_field_case_logic.py
+++ b/tests/test_get_field_case_logic.py
@@ -1,0 +1,53 @@
+"""Additional tests to verify the get_field_case implementation logic."""
+
+from graphql import GraphQLField, GraphQLList, GraphQLNonNull, GraphQLString
+
+from s2dm.exporters.utils import FieldCase, get_field_case
+
+
+def test_get_field_case_implementation_logic() -> None:
+    """Test the implementation logic of get_field_case with manually constructed GraphQL types."""
+
+    # Test DEFAULT: String
+    field_default = GraphQLField(GraphQLString)
+    assert get_field_case(field_default) == FieldCase.DEFAULT
+
+    # Test NON_NULL: String!
+    field_non_null = GraphQLField(GraphQLNonNull(GraphQLString))
+    assert get_field_case(field_non_null) == FieldCase.NON_NULL
+
+    # Test LIST: [String]
+    field_list = GraphQLField(GraphQLList(GraphQLString))
+    assert get_field_case(field_list) == FieldCase.LIST
+
+    # Test NON_NULL_LIST: [String]!
+    field_non_null_list = GraphQLField(GraphQLNonNull(GraphQLList(GraphQLString)))
+    assert get_field_case(field_non_null_list) == FieldCase.NON_NULL_LIST
+
+    # Test LIST_NON_NULL: [String!]
+    field_list_non_null = GraphQLField(GraphQLList(GraphQLNonNull(GraphQLString)))
+    assert get_field_case(field_list_non_null) == FieldCase.LIST_NON_NULL
+
+    # Test NON_NULL_LIST_NON_NULL: [String!]!
+    field_non_null_list_non_null = GraphQLField(GraphQLNonNull(GraphQLList(GraphQLNonNull(GraphQLString))))
+    assert get_field_case(field_non_null_list_non_null) == FieldCase.NON_NULL_LIST_NON_NULL
+
+
+def test_get_field_case_edge_cases() -> None:
+    """Test edge cases and nested type unwrapping."""
+
+    # Deep nesting should still work correctly
+    deeply_nested = GraphQLNonNull(GraphQLList(GraphQLNonNull(GraphQLString)))
+    field = GraphQLField(deeply_nested)
+    assert get_field_case(field) == FieldCase.NON_NULL_LIST_NON_NULL
+
+    # Single non-null
+    single_non_null = GraphQLNonNull(GraphQLString)
+    field_single = GraphQLField(single_non_null)
+    assert get_field_case(field_single) == FieldCase.NON_NULL
+
+
+if __name__ == "__main__":
+    test_get_field_case_implementation_logic()
+    test_get_field_case_edge_cases()
+    print("All implementation logic tests passed!")

--- a/tests/test_type_modifiers/test_spec.graphql
+++ b/tests/test_type_modifiers/test_spec.graphql
@@ -2,52 +2,70 @@
 type TestTypeModifiers {
     # A - field.case.DEFAULT
     """Example (A.1) DEFAULT with scalar output type"""
-    defaultScalar: Boolean
+    defaultScalar: Boolean @metadata(comment: "Comment example A.1")
     """Example (A.2) DEFAULT with object output type"""
-    defaultType: ExampleType
+    defaultType: ExampleType @metadata(comment: "Comment example A.2")
     """Example (A.3) DEFAULT with object output type with instances"""
-    defaultWithInstances: ExampleTypeWithInstances
+    defaultWithInstances: ExampleTypeWithInstances @metadata(comment: "Comment example A.3")
 
 
     # B - field.case.NON_NULL
     """Example (B.1) NON_NULL with scalar output type"""
-    nonNullScalar: Boolean!
+    nonNullScalar: Boolean! @metadata(comment: "Comment example B.1")
     """Example (B.2) NON_NULL with object output type"""
-    nonNull: ExampleType!
+    nonNull: ExampleType! @metadata(comment: "Comment example B.2")
     """Example (B.3) NON_NULL with object output type with instances"""
-    nonNullWithInstances: ExampleTypeWithInstances!
+    nonNullWithInstances: ExampleTypeWithInstances! @metadata(comment: "Comment example B.3")
 
     # C - field.case.LIST
-    #listScalar: [Boolean]
-    #list: [ExampleType]
-    #listWithInstances: [ExampleTypeWithInstances]
+    """Example (C.1) LIST with scalar output type"""
+    listScalar: [Boolean] @metadata(comment: "Comment example C.1")
+    """Example (C.2) LIST with object output type"""
+    list: [ExampleType] @metadata(comment: "Comment example C.2")
+    """Example (C.3) LIST with object output type with instances"""
+    listWithInstances: [ExampleTypeWithInstances] @metadata(comment: "Comment example C.3")
 
     # D - field.case.NON_NULL_LIST
-    #nonNullListScalar: [Boolean]!
-    #nonNullList: [ExampleType]!
-    #nonNullListWithInstances: [ExampleTypeWithInstances]!
+    """Example (D.1) NON_NULL_LIST with scalar output type"""
+    nonNullListScalar: [Boolean]! @metadata(comment: "Comment example D.1")
+    """Example (D.2) NON_NULL_LIST with object output type"""
+    nonNullList: [ExampleType]! @metadata(comment: "Comment example D.2")
+    """Example (D.3) NON_NULL_LIST with object output type with instances"""
+    nonNullListWithInstances: [ExampleTypeWithInstances]! @metadata(comment: "Comment example D.3")
 
     # E - field.case.LIST_NON_NULL
-    #listNonNullScalar: [Boolean!]
-    #listNonNull: [ExampleType!]
-    #listNonNullWithInstances: [ExampleTypeWithInstances!]
+    """Example (E.1) LIST_NON_NULL with scalar output type"""
+    listNonNullScalar: [Boolean!] @metadata(comment: "Comment example E.1")
+    """Example (E.2) LIST_NON_NULL with object output type"""
+    listNonNull: [ExampleType!] @metadata(comment: "Comment example E.2")
+    """Example (E.3) LIST_NON_NULL with object output type with instances"""
+    listNonNullWithInstances: [ExampleTypeWithInstances!] @metadata(comment: "Comment example E.3")
 
     # F - field.case.NON_NULL_LIST_NON_NULL
-    #nonNullListNonNullScalar: [Boolean!]!
-    #nonNullListNonNull: [ExampleType!]!
-    #nonNullListNonNullWithInstances: [ExampleTypeWithInstances!]!
+    """Example (F.1) NON_NULL_LIST_NON_NULL with scalar output type"""
+    nonNullListNonNullScalar: [Boolean!]! @metadata(comment: "Comment example F.1")
+    """Example (F.2) NON_NULL_LIST_NON_NULL with object output type"""
+    nonNullListNonNull: [ExampleType!]! @metadata(comment: "Comment example F.2")
+    """Example (F.3) NON_NULL_LIST_NON_NULL with object output type with instances"""
+    nonNullListNonNullWithInstances: [ExampleTypeWithInstances!]! @metadata(comment: "Comment example F.3")
 
     # G - field.case.SET
-    setScalar: [Boolean] @noDuplicates @cardinality(max:5)
-    set: [ExampleType] @noDuplicates @cardinality(max:5)
-    setEnum: [SomeEnum] @noDuplicates @cardinality(max:5)
-    setWithInstances: [ExampleTypeWithInstances] @noDuplicates @cardinality(max:5)
+    """Example (G.1) SET with scalar output type"""
+    setScalar: [Boolean] @noDuplicates @cardinality(max:5) @metadata(comment: "Comment example G.1")
+    """Example (G.2) SET with object output type"""
+    set: [ExampleType] @noDuplicates @cardinality(max:5) @metadata(comment: "Comment example G.2")
+    """Example (G.3) SET with enum output type"""
+    setEnum: [SomeEnum] @noDuplicates @cardinality(max:5) @metadata(comment: "Comment example G.3")
+    """Example (G.4) SET with object output type with instances"""
+    setWithInstances: [ExampleTypeWithInstances] @noDuplicates @cardinality(max:5) @metadata(comment: "Comment example G.4")
 
     # H - field.case.SET_NON_NULL
-    setNonNullScalar: [Boolean!] @noDuplicates @cardinality(max:10)
-    setNonNull: [ExampleType!] @noDuplicates @cardinality(max:10)
-    setNonNullWithInstances: [ExampleTypeWithInstances!] @noDuplicates @cardinality(max:10)
-
+    """Example (H.1) SET_NON_NULL with scalar output type"""
+    setNonNullScalar: [Boolean!] @noDuplicates @cardinality(max:10) @metadata(comment: "Comment example H.1")
+    """Example (H.2) SET_NON_NULL with object output type"""
+    setNonNull: [ExampleType!] @noDuplicates @cardinality(max:10) @metadata(comment: "Comment example H.2")
+    """Example (H.3) SET_NON_NULL with enum output type"""
+    setNonNullWithInstances: [ExampleTypeWithInstances!] @noDuplicates @cardinality(max:10) @metadata(comment: "Comment example H.3")
 }
 
 type ExampleType {


### PR DESCRIPTION
- Solves issue #75.
- Fixes mistake in test spec file used for the different combinations of output types in graphql.
- Adds a couple of tests.