### PR TITLE
ci: add DEPLOY_KEY to allow pushing to main from github actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
         with:
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
           fetch-depth: 0
 
       - name: setup python


### PR DESCRIPTION
update repository settings to allow pushing from a `DEPLOY_KEY` to fix the release workflow