### PR TITLE
Fix/jsonschema exporter

### DIFF
--- a/src/s2dm/cli.py
+++ b/src/s2dm/cli.py
@@ -251,9 +251,16 @@ def vspec(schema: Path, output: Path) -> None:
     default=False,
     help="Enforce strict field nullability translation from GraphQL to JSON Schema",
 )
-def jsonschema(schema: Path, output: Path, root_type: str | None, strict: bool) -> None:
+@click.option(
+    "--expanded-instances",
+    "-e",
+    is_flag=True,
+    default=False,
+    help="Expand instance tags into nested structure instead of arrays",
+)
+def jsonschema(schema: Path, output: Path, root_type: str | None, strict: bool, expanded_instances: bool) -> None:
     """Generate JSON Schema from a given GraphQL schema."""
-    result = translate_to_jsonschema(schema, root_type, strict)
+    result = translate_to_jsonschema(schema, root_type, strict, expanded_instances)
     _ = output.write_text(result)
 
 

--- a/src/s2dm/exporters/jsonschema/jsonschema.py
+++ b/src/s2dm/exporters/jsonschema/jsonschema.py
@@ -9,7 +9,9 @@ from s2dm.exporters.utils import load_schema
 from .transformer import JsonSchemaTransformer
 
 
-def transform(graphql_schema: GraphQLSchema, root_type: str | None = None, strict: bool = False) -> str:
+def transform(
+    graphql_schema: GraphQLSchema, root_type: str | None = None, strict: bool = False, expanded_instances: bool = False
+) -> str:
     """
     Transform a GraphQL schema object to JSON Schema format.
 
@@ -17,6 +19,7 @@ def transform(graphql_schema: GraphQLSchema, root_type: str | None = None, stric
         graphql_schema: The GraphQL schema object to transform
         root_type: Optional root type name for the JSON schema
         strict: Enforce strict field nullability translation from GraphQL to JSON Schema
+        expanded_instances: Expand instance tags into nested structure instead of arrays
 
     Returns:
         str: JSON Schema representation as a string
@@ -28,7 +31,7 @@ def transform(graphql_schema: GraphQLSchema, root_type: str | None = None, stric
             raise ValueError(f"Root type '{root_type}' not found in schema")
         log.info(f"Using root type: {root_type}")
 
-    transformer = JsonSchemaTransformer(graphql_schema, root_type, strict)
+    transformer = JsonSchemaTransformer(graphql_schema, root_type, strict, expanded_instances)
     json_schema = transformer.transform()
 
     json_schema_str = json.dumps(json_schema, indent=2)
@@ -38,7 +41,9 @@ def transform(graphql_schema: GraphQLSchema, root_type: str | None = None, stric
     return json_schema_str
 
 
-def translate_to_jsonschema(schema_path: Path, root_type: str | None = None, strict: bool = False) -> str:
+def translate_to_jsonschema(
+    schema_path: Path, root_type: str | None = None, strict: bool = False, expanded_instances: bool = False
+) -> str:
     """
     Translate a GraphQL schema file to JSON Schema format.
 
@@ -46,6 +51,7 @@ def translate_to_jsonschema(schema_path: Path, root_type: str | None = None, str
         schema_path: Path to a GraphQL schema file or directory containing schema files
         root_type: Optional root type name for the JSON schema
         strict: Enforce strict field nullability translation from GraphQL to JSON Schema
+        expanded_instances: Expand instance tags into nested structure instead of arrays
 
     Returns:
         str: JSON Schema representation as a string
@@ -55,4 +61,4 @@ def translate_to_jsonschema(schema_path: Path, root_type: str | None = None, str
     graphql_schema = load_schema(schema_path)
     log.info(f"Successfully loaded GraphQL schema with {len(graphql_schema.type_map)} types")
 
-    return transform(graphql_schema, root_type, strict)
+    return transform(graphql_schema, root_type, strict, expanded_instances)

--- a/tests/test_expanded_instances/__init__.py
+++ b/tests/test_expanded_instances/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for expanded instances functionality."""

--- a/tests/test_expanded_instances/test_expanded_instances.py
+++ b/tests/test_expanded_instances/test_expanded_instances.py
@@ -1,0 +1,181 @@
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from s2dm.exporters.jsonschema import translate_to_jsonschema
+
+
+class TestExpandedInstances:
+    """Test the expanded instances functionality for JSON Schema export."""
+
+    @pytest.fixture
+    def test_schema_path(self) -> Path:
+        """Path to the test GraphQL schema."""
+        return Path(__file__).parent / "test_schema.graphql"
+
+    def test_default_behavior_creates_arrays(self, test_schema_path: Path) -> None:
+        """Test that the default behavior creates arrays for instance tagged objects."""
+        result = translate_to_jsonschema(test_schema_path, root_type="Cabin")
+        schema = json.loads(result)
+
+        # Check that doors is an array
+        doors_def = schema["$defs"]["Cabin"]["properties"]["doors"]
+        assert doors_def["type"] == "array"
+        assert "items" in doors_def
+
+        # Check that seats is an array
+        seats_def = schema["$defs"]["Cabin"]["properties"]["seats"]
+        assert seats_def["type"] == "array"
+        assert "items" in seats_def
+
+    def test_expanded_instances_creates_nested_objects(self, test_schema_path: Path) -> None:
+        """Test that expanded_instances=True creates nested object structures."""
+        result = translate_to_jsonschema(test_schema_path, root_type="Cabin", expanded_instances=True)
+        schema = json.loads(result)
+
+        # Check that Doors becomes Door (singular) and is a nested object structure
+        door_def = schema["$defs"]["Cabin"]["properties"]["Door"]
+        assert door_def["type"] == "object"
+        assert "properties" in door_def
+
+        # Should have ROW1 and ROW2
+        assert "ROW1" in door_def["properties"]
+        assert "ROW2" in door_def["properties"]
+
+        # Each row should have DRIVERSIDE and PASSENGERSIDE
+        row1 = door_def["properties"]["ROW1"]
+        assert row1["type"] == "object"
+        assert "DRIVERSIDE" in row1["properties"]
+        assert "PASSENGERSIDE" in row1["properties"]
+
+        # Each door position should have the door properties
+        driver_door = row1["properties"]["DRIVERSIDE"]
+        assert driver_door["type"] == "object"
+        assert "isLocked" in driver_door["properties"]
+        assert "position" in driver_door["properties"]
+        assert driver_door["properties"]["isLocked"]["type"] == "boolean"
+        assert driver_door["properties"]["position"]["type"] == "integer"
+
+    def test_expanded_instances_for_seats(self, test_schema_path: Path) -> None:
+        """Test expanded instances for seats with 3-level nesting."""
+        result = translate_to_jsonschema(test_schema_path, root_type="Cabin", expanded_instances=True)
+        schema = json.loads(result)
+
+        # Check that Seats becomes Seat (singular) and is a nested object structure
+        seat_def = schema["$defs"]["Cabin"]["properties"]["Seat"]
+        assert seat_def["type"] == "object"
+        assert "properties" in seat_def
+
+        # Should have ROW1, ROW2, ROW3
+        assert "ROW1" in seat_def["properties"]
+        assert "ROW2" in seat_def["properties"]
+        assert "ROW3" in seat_def["properties"]
+
+        # Each row should have LEFT, CENTER, RIGHT
+        row1 = seat_def["properties"]["ROW1"]
+        assert row1["type"] == "object"
+        assert "LEFT" in row1["properties"]
+        assert "CENTER" in row1["properties"]
+        assert "RIGHT" in row1["properties"]
+
+        # Each seat position should have the seat properties
+        left_seat = row1["properties"]["LEFT"]
+        assert left_seat["type"] == "object"
+        assert "isOccupied" in left_seat["properties"]
+        assert "height" in left_seat["properties"]
+        assert left_seat["properties"]["isOccupied"]["type"] == "boolean"
+        assert left_seat["properties"]["height"]["type"] == "integer"
+
+    def test_non_instance_tagged_objects_remain_arrays(self, test_schema_path: Path) -> None:
+        """Test that objects without instance tags remain as arrays even with expanded_instances=True."""
+        # Create a schema with both instance-tagged and regular arrays
+        extended_schema = """
+        enum RowEnum {
+          ROW1
+          ROW2
+        }
+
+        enum SideEnum {
+          DRIVERSIDE
+          PASSENGERSIDE
+        }
+
+        type DoorPosition @instanceTag {
+          Row: RowEnum!
+          Side: SideEnum!
+        }
+
+        type Door {
+          isLocked: Boolean
+          instanceTag: DoorPosition
+        }
+
+        type RegularItem {
+          name: String
+          value: Int
+        }
+
+        type TestObject {
+          doorsWithInstanceTag: [Door] @noDuplicates
+          regularItems: [RegularItem] @noDuplicates
+        }
+        """
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".graphql", delete=False) as f:
+            f.write(extended_schema)
+            temp_path = Path(f.name)
+
+        try:
+            result = translate_to_jsonschema(temp_path, root_type="TestObject", expanded_instances=True)
+            schema = json.loads(result)
+
+            # Instance-tagged doors should be expanded and use singular name
+            doors_def = schema["$defs"]["TestObject"]["properties"]["Door"]
+            assert doors_def["type"] == "object"
+            assert "properties" in doors_def
+
+            # Regular items should remain as array
+            items_def = schema["$defs"]["TestObject"]["properties"]["regularItems"]
+            assert items_def["type"] == "array"
+            assert "items" in items_def
+
+        finally:
+            temp_path.unlink()
+
+    def test_expanded_instances_with_strict_mode(self, test_schema_path: Path) -> None:
+        """Test that expanded instances work correctly with strict mode."""
+        result = translate_to_jsonschema(test_schema_path, root_type="Cabin", strict=True, expanded_instances=True)
+        schema = json.loads(result)
+
+        # Should still create expanded structure with singular naming
+        door_def = schema["$defs"]["Cabin"]["properties"]["Door"]
+        assert door_def["type"] == "object"
+        assert "ROW1" in door_def["properties"]
+
+        # Properties should still have correct types (in strict mode, nullable fields become arrays)
+        driver_door = door_def["properties"]["ROW1"]["properties"]["DRIVERSIDE"]
+        islocked_type = driver_door["properties"]["isLocked"]["type"]
+        # In strict mode, nullable boolean becomes ["boolean", "null"]
+        assert islocked_type == ["boolean", "null"] or islocked_type == "boolean"
+
+    def test_singular_naming_for_expanded_instances(self, test_schema_path: Path) -> None:
+        """Test that expanded instances use singular type names instead of field names."""
+        result_normal = translate_to_jsonschema(test_schema_path, root_type="Cabin", expanded_instances=False)
+        result_expanded = translate_to_jsonschema(test_schema_path, root_type="Cabin", expanded_instances=True)
+
+        schema_normal = json.loads(result_normal)
+        schema_expanded = json.loads(result_expanded)
+
+        # Normal behavior should use plural field names
+        assert "doors" in schema_normal["$defs"]["Cabin"]["properties"]
+        assert "seats" in schema_normal["$defs"]["Cabin"]["properties"]
+
+        # Expanded behavior should use singular type names
+        assert "Door" in schema_expanded["$defs"]["Cabin"]["properties"]
+        assert "Seat" in schema_expanded["$defs"]["Cabin"]["properties"]
+
+        # The original plural field names should not exist in expanded version
+        assert "doors" not in schema_expanded["$defs"]["Cabin"]["properties"]
+        assert "seats" not in schema_expanded["$defs"]["Cabin"]["properties"]

--- a/tests/test_expanded_instances/test_schema.graphql
+++ b/tests/test_expanded_instances/test_schema.graphql
@@ -1,0 +1,55 @@
+enum RowEnum {
+  ROW1
+  ROW2
+}
+
+enum SideEnum {
+  DRIVERSIDE
+  PASSENGERSIDE
+}
+
+type DoorPosition @instanceTag {
+  row: RowEnum!
+  side: SideEnum!
+}
+
+type Door {
+  isLocked: Boolean
+  position: Int
+  instanceTag: DoorPosition
+}
+
+type Vehicle {
+  doors: [Door] @noDuplicates
+  model: String
+  year: Int
+}
+
+enum SeatRowEnum {
+  ROW1
+  ROW2
+  ROW3
+}
+
+enum SeatPositionEnum {
+  LEFT
+  CENTER
+  RIGHT
+}
+
+type SeatPosition @instanceTag {
+  row: SeatRowEnum!
+  position: SeatPositionEnum!
+}
+
+type Seat {
+  isOccupied: Boolean
+  height: Int
+  instanceTag: SeatPosition
+}
+
+type Cabin {
+  seats: [Seat] @noDuplicates
+  doors: [Door] @noDuplicates
+  temperature: Float
+}


### PR DESCRIPTION
Adds a new --expanded-instances CLI option to the JSON Schema export command that transforms arrays with instance tags into nested object structures using singular type names.

Example:

Normal: `"doors": {"type": "array", "items": {...}}`
Expanded: `"Door": {"type": "object", "properties": {"ROW1": {...}}}`
Changes:

New CLI flag: `--expanded-instances/-e` (default: false)
Transforms `fieldName: [TypeName]` → uses TypeName as property key
Maintains backward compatibility
Includes comprehensive test suite (6 test cases)