### PR TITLE
Fix/jsonschema expansion

### DIFF
--- a/src/s2dm/exporters/jsonschema/transformer.py
+++ b/src/s2dm/exporters/jsonschema/transformer.py
@@ -433,13 +433,8 @@ class JsonSchemaTransformer:
 
                 if part not in current_definition:
                     if is_last_split_element:
-                        # For the last element, add the actual object properties
-                        current_definition[part] = {"additionalProperties": False, "properties": {}, "type": "object"}
-                        # Add all properties from the original object type
-                        for field_name, field in object_type.fields.items():
-                            if field_name != "instanceTag":  # Skip the instanceTag field itself
-                                field_definition = self.transform_field(field)
-                                current_definition[part]["properties"][field_name] = field_definition
+                        # For the last element, use a reference to the object type
+                        current_definition[part] = {"$ref": f"#/$defs/{object_type.name}"}
                     else:
                         current_definition[part] = {
                             "additionalProperties": False,

--- a/tests/test_expanded_instances/test_nested_schema.graphql
+++ b/tests/test_expanded_instances/test_nested_schema.graphql
@@ -1,0 +1,35 @@
+enum TwoRowsEnum {
+  ROW1
+  ROW2
+}
+
+enum LateralPositionEnum {
+  LEFT
+  RIGHT
+}
+
+type ChassisAxleRowTag @instanceTag {
+  row: TwoRowsEnum
+}
+
+type LateralPositionTag @instanceTag {
+  position: LateralPositionEnum
+}
+
+type Chassis {
+  Axles: [Axle] @noDuplicates
+}
+
+type Axle {
+  instanceTag: ChassisAxleRowTag
+  Wheels: [Wheel] @noDuplicates
+}
+
+type Wheel {
+  instanceTag: LateralPositionTag
+  Tire: Tire
+}
+
+type Tire {
+  Pressure: Float @range(min: 0)
+}


### PR DESCRIPTION
Fix nested instance expansion in JSON Schema export to use $ref references instead of copying object properties inline, resolving incorrect field naming and bloated output when using the -e flag.

- The problem (nested instance expansion issues)
- The solution ($ref references instead of inline copying)
- The impact (fixes field naming and reduces bloat)
- The context (JSON Schema export with -e flag)