### PR TITLE
feat: naming case conversion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "pyshacl>=0.30.0",
     "ariadne>=0.24.0",
     "langcodes>=3.5.0",
+    "case-converter>=1.2.0",
 ]
 requires-python = ">=3.11"
 

--- a/src/s2dm/exporters/README.md
+++ b/src/s2dm/exporters/README.md
@@ -649,6 +649,101 @@ You can call the help for usage reference:
 s2dm export jsonschema --help
 ```
 
+## Naming Configuration
+
+All export commands support a global naming configuration feature that allows you to transform element names during the export process using the `[--naming-config | -n]` flag.
+
+### Usage
+
+Apply naming configuration to any export command:
+
+```bash
+s2dm export [--naming-config | -n] naming.yaml ...
+```
+
+### Configuration Format
+
+The naming configuration is defined in a YAML file with the following structure:
+
+```yaml
+# Transform type names by type context
+type:
+  object: "PascalCase"
+  interface: "PascalCase"
+  input: "PascalCase"
+  enum: "PascalCase"
+  union: "PascalCase"
+  scalar: "PascalCase"
+
+# Transform field names by parent type context
+field:
+  object: "camelCase"
+  interface: "camelCase"
+  input: "snake_case"
+
+# Transform enum values (no context needed)
+enumValue: "MACROCASE"
+
+# Transform argument names by context
+argument:
+  field: "camelCase"
+```
+
+### Supported Case Formats
+
+The naming configuration supports the following case conversion formats:
+
+- **camelCase**: `myVariableName`
+- **PascalCase**: `MyVariableName`
+- **snake_case**: `my_variable_name`
+- **kebab-case**: `my-variable-name`
+- **MACROCASE**: `MY_VARIABLE_NAME`
+- **COBOL-CASE**: `MY-VARIABLE-NAME`
+- **flatcase**: `myvariablename`
+- **TitleCase**: `My Variable Name`
+
+### Example Conversion
+
+Given this GraphQL schema:
+
+```graphql
+type vehicle_info {
+  avg_speed: Float
+  fuel_type: fuel_type_enum
+}
+
+enum fuel_type_enum {
+  GASOLINE_TYPE
+  DIESEL_TYPE
+}
+```
+
+And this naming configuration:
+
+```yaml
+type:
+  object: "PascalCase"
+  enum: "PascalCase"
+field:
+  object: "camelCase"
+enumValue: "PascalCase"
+```
+
+The exported schema will transform names as follows:
+
+- Type: `vehicle_info` → `VehicleInfo`
+- Field: `avg_speed` → `avgSpeed`  
+- Field: `fuel_type` → `fuelType`
+- Enum type: `fuel_type_enum` → `FuelTypeEnum`
+- Enum values: `GASOLINE_TYPE` → `GasolineType`, `DIESEL_TYPE` → `DieselType`
+
+### Notes
+
+- Built-in GraphQL types (`String`, `Int`, `Float`, `Boolean`, `ID`, `Query`, `Mutation`, `Subscription`) are never transformed
+- If a configuration is not provided for an element type, the original names are preserved
+- Invalid case format names are ignored and original names are kept
+- Configuration is loaded once at the command level and applied consistently across the entire export process
+
 ## Identifiers
 With the asumption that specification files will be hosted in a certain Git repository, the tools include functions to support the proper identification of concepts and their metadata to facilite their evolution.
 The identification process is based on the following principles, which are describes in the rest of this subsection:

--- a/src/s2dm/exporters/jsonschema/jsonschema.py
+++ b/src/s2dm/exporters/jsonschema/jsonschema.py
@@ -1,10 +1,11 @@
 import json
 from pathlib import Path
+from typing import Any
 
 from graphql import GraphQLSchema
 
 from s2dm import log
-from s2dm.exporters.utils import load_schema
+from s2dm.exporters.utils import load_schema_with_naming
 
 from .transformer import JsonSchemaTransformer
 
@@ -42,7 +43,11 @@ def transform(
 
 
 def translate_to_jsonschema(
-    schema_path: Path, root_type: str | None = None, strict: bool = False, expanded_instances: bool = False
+    schema_path: Path,
+    root_type: str | None = None,
+    strict: bool = False,
+    expanded_instances: bool = False,
+    naming_config: dict[str, Any] | None = None,
 ) -> str:
     """
     Translate a GraphQL schema file to JSON Schema format.
@@ -58,7 +63,7 @@ def translate_to_jsonschema(
     """
     log.info(f"Loading GraphQL schema from: {schema_path}")
 
-    graphql_schema = load_schema(schema_path)
+    graphql_schema = load_schema_with_naming(schema_path, naming_config)
     log.info(f"Successfully loaded GraphQL schema with {len(graphql_schema.type_map)} types")
 
     return transform(graphql_schema, root_type, strict, expanded_instances)

--- a/src/s2dm/exporters/naming_utils.py
+++ b/src/s2dm/exporters/naming_utils.py
@@ -1,0 +1,156 @@
+from typing import Any
+
+from caseconverter import camelcase, cobolcase, flatcase, kebabcase, macrocase, pascalcase, snakecase, titlecase
+from graphql import (
+    GraphQLEnumType,
+    GraphQLInputObjectType,
+    GraphQLInterfaceType,
+    GraphQLObjectType,
+    GraphQLScalarType,
+    GraphQLSchema,
+    GraphQLUnionType,
+)
+
+
+def convert_name(name: str, target_case: str) -> str:
+    case_converters = {
+        "camelCase": camelcase,
+        "PascalCase": pascalcase,
+        "snake_case": snakecase,
+        "kebab-case": kebabcase,
+        "MACROCASE": macrocase,
+        "COBOL-CASE": cobolcase,
+        "flatcase": flatcase,
+        "TitleCase": titlecase,
+    }
+
+    if target_case in case_converters:
+        return str(case_converters[target_case](name))
+    return name
+
+
+def get_target_case_for_element(element_type: str, context: str, naming_config: dict[str, Any]) -> str | None:
+    if element_type in naming_config:
+        config_section = naming_config[element_type]
+        if isinstance(config_section, dict) and context in config_section:
+            return str(config_section[context])
+        elif isinstance(config_section, str):
+            return str(config_section)
+    return None
+
+
+def apply_naming_to_schema(schema: GraphQLSchema, naming_config: dict[str, Any]) -> GraphQLSchema:
+    """Apply naming conversion to a GraphQL schema by modifying object names directly."""
+    type_contexts = {
+        GraphQLObjectType: "object",
+        GraphQLInterfaceType: "interface",
+        GraphQLInputObjectType: "input",
+        GraphQLEnumType: "enum",
+        GraphQLUnionType: "union",
+        GraphQLScalarType: "scalar",
+    }
+
+    new_type_map = {}
+    for type_name, type_obj in schema.type_map.items():
+        if type_name.startswith("__") or type_name in {
+            "String",
+            "Int",
+            "Float",
+            "Boolean",
+            "ID",
+            "Query",
+            "Mutation",
+            "Subscription",
+        }:
+            new_type_map[type_name] = type_obj
+            continue
+
+        context = type_contexts.get(type(type_obj))
+        if context:
+            target_case = get_target_case_for_element("type", context, naming_config)
+            if target_case:
+                new_name = convert_name(type_name, target_case)
+                if new_name != type_name:
+                    type_obj.name = new_name
+                    new_type_map[new_name] = type_obj
+                    continue
+
+        new_type_map[type_name] = type_obj
+
+    for type_obj in new_type_map.values():
+        if isinstance(type_obj, GraphQLObjectType | GraphQLInterfaceType | GraphQLInputObjectType):
+            convert_field_names(type_obj, naming_config)
+        elif isinstance(type_obj, GraphQLEnumType):
+            convert_enum_values(type_obj, naming_config)
+
+    return GraphQLSchema(
+        query=schema.query_type,
+        mutation=schema.mutation_type,
+        subscription=schema.subscription_type,
+        types=list(new_type_map.values()),
+        directives=schema.directives,
+        description=schema.description,
+        extensions=schema.extensions,
+    )
+
+
+def convert_names_in_collection(
+    collection: dict[str, Any], element_type: str, context: str, naming_config: dict[str, Any]
+) -> None:
+    target_case = get_target_case_for_element(element_type, context, naming_config)
+    if not target_case:
+        return
+
+    for name, item in collection.items():
+        new_name = convert_name(name, target_case)
+        if new_name != name:
+            item.name = new_name
+
+
+def convert_field_names(
+    type_obj: GraphQLObjectType | GraphQLInterfaceType | GraphQLInputObjectType, naming_config: dict[str, Any]
+) -> None:
+    type_contexts = {GraphQLObjectType: "object", GraphQLInterfaceType: "interface", GraphQLInputObjectType: "input"}
+
+    context = type_contexts.get(type(type_obj))
+    if not context:
+        return
+
+    target_case = get_target_case_for_element("field", context, naming_config)
+    if target_case:
+        new_fields = {}
+        for old_name, field in type_obj.fields.items():
+            new_name = convert_name(old_name, target_case)
+            new_fields[new_name] = field
+
+        type_obj.fields.clear()
+        type_obj.fields.update(new_fields)
+
+    if context in ("object", "interface"):
+        for field in type_obj.fields.values():
+            if hasattr(field, "args") and field.args:
+                # Convert argument names - need to update dictionary keys (args don't have .name attribute)
+                arg_target_case = get_target_case_for_element("argument", "field", naming_config)
+                if arg_target_case:
+                    new_args = {}
+                    for old_name, arg in field.args.items():
+                        new_name = convert_name(old_name, arg_target_case)
+                        new_args[new_name] = arg
+
+                    # Replace the args dictionary
+                    field.args.clear()
+                    field.args.update(new_args)
+
+
+def convert_enum_values(type_obj: GraphQLEnumType, naming_config: dict[str, Any]) -> None:
+    target_case = get_target_case_for_element("enumValue", "", naming_config)
+    if not target_case:
+        return
+
+    new_values = {}
+    for old_name, enum_value in type_obj.values.items():
+        new_name = convert_name(old_name, target_case)
+        new_values[new_name] = enum_value
+
+    type_obj.values.clear()
+    type_obj.values.update(new_values)

--- a/src/s2dm/exporters/shacl.py
+++ b/src/s2dm/exporters/shacl.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from pathlib import Path
-from typing import cast
+from typing import Any, cast
 
 from graphql import (
     GraphQLEnumType,
@@ -25,7 +25,7 @@ from s2dm.exporters.utils import (
     get_instance_tag_object,
     has_directive,
     has_valid_instance_tag_field,
-    load_schema,
+    load_schema_with_naming,
     print_field_sdl,
 )
 
@@ -66,6 +66,7 @@ def translate_to_shacl(
     shapes_namespace_prefix: str,
     model_namespace: str,
     model_namespace_prefix: str,
+    naming_config: dict[str, Any] | None = None,
 ) -> Graph:
     """Translate a GraphQL schema to SHACL."""
     namespaces = Namespaces(
@@ -74,7 +75,7 @@ def translate_to_shacl(
         Namespace(model_namespace),
         Namespace(model_namespace_prefix),
     )
-    schema = load_schema(schema_path)
+    schema = load_schema_with_naming(schema_path, naming_config)
     graph = Graph()
     graph.bind(namespaces.shapes_prefix, namespaces.shapes)
     graph.bind(namespaces.model_prefix, namespaces.model)

--- a/src/s2dm/exporters/utils.py
+++ b/src/s2dm/exporters/utils.py
@@ -36,6 +36,8 @@ from graphql.utilities import print_schema
 
 from s2dm import log
 
+from .naming_utils import apply_naming_to_schema
+
 
 def read_file(file_path: Path) -> str:
     """
@@ -630,3 +632,11 @@ def get_referenced_types(graphql_schema: GraphQLSchema, root_type: str) -> set[G
 
     log.info(f"Found {len(referenced)} referenced types from root type '{root_type}'")
     return referenced
+
+
+def load_schema_with_naming(schema_path: Path, naming_config: dict[str, Any] | None = None) -> GraphQLSchema:
+    """Load schema and apply naming conversion."""
+    schema = load_schema(schema_path)
+    if naming_config:
+        schema = apply_naming_to_schema(schema, naming_config)
+    return schema

--- a/src/s2dm/exporters/vspec.py
+++ b/src/s2dm/exporters/vspec.py
@@ -22,7 +22,7 @@ from s2dm.exporters.utils import (
     get_instance_tag_dict,
     get_instance_tag_object,
     has_directive,
-    load_schema,
+    load_schema_with_naming,
 )
 
 UNITS_DICT = {  # TODO: move to a separate file or use the vss tools to get the mapping directly from dynamic_units
@@ -161,9 +161,9 @@ class CustomDumper(yaml.Dumper):
 CustomDumper.add_representer(list, CustomDumper.represent_list)
 
 
-def translate_to_vspec(schema_path: Path) -> str:
+def translate_to_vspec(schema_path: Path, naming_config: dict[str, Any] | None = None) -> str:
     """Translate a GraphQL schema to YAML."""
-    schema = load_schema(schema_path)
+    schema = load_schema_with_naming(schema_path, naming_config)
 
     all_object_types = get_all_object_types(schema)
     log.debug(f"Object types: {all_object_types}")

--- a/tests/test_naming_utils.py
+++ b/tests/test_naming_utils.py
@@ -1,0 +1,288 @@
+import pytest
+from graphql import (
+    GraphQLArgument,
+    GraphQLEnumType,
+    GraphQLEnumValue,
+    GraphQLField,
+    GraphQLInputField,
+    GraphQLInputObjectType,
+    GraphQLInterfaceType,
+    GraphQLObjectType,
+    GraphQLSchema,
+    GraphQLString,
+)
+
+from s2dm.exporters.naming_utils import (
+    apply_naming_to_schema,
+    convert_enum_values,
+    convert_field_names,
+    convert_name,
+    get_target_case_for_element,
+)
+
+
+class TestConvertName:
+    """Test individual name conversion functions."""
+
+    @pytest.mark.parametrize(
+        "input_name,target_case,expected",
+        [
+            ("HelloWorld", "camelCase", "helloWorld"),
+            ("hello_world", "PascalCase", "HelloWorld"),
+            ("HelloWorld", "snake_case", "hello_world"),
+            ("hello world", "kebab-case", "hello-world"),
+            ("HelloWorld", "MACROCASE", "HELLO_WORLD"),
+            ("hello-world", "COBOL-CASE", "HELLO-WORLD"),
+            ("Hello World", "flatcase", "helloworld"),
+            ("hello_world", "TitleCase", "Hello World"),
+        ],
+    )
+    def test_convert_name_supported_cases(self, input_name: str, target_case: str, expected: str) -> None:
+        """Test conversion for all supported case formats."""
+        result = convert_name(input_name, target_case)
+        assert result == expected
+
+    def test_convert_name_unsupported_case(self) -> None:
+        """Test that unsupported cases return the original name."""
+        original = "HelloWorld"
+        result = convert_name(original, "unsupported_case")
+        assert result == original
+
+    def test_convert_name_empty_string(self) -> None:
+        """Test conversion with empty string input."""
+        result = convert_name("", "camelCase")
+        assert result == ""
+
+
+class TestGetTargetCaseForElement:
+    """Test getting target case configuration for different element types."""
+
+    def test_hierarchical_config(self) -> None:
+        """Test hierarchical configuration lookup."""
+        config = {"field": {"object": "camelCase", "interface": "snake_case"}, "enumValue": "macrocase"}
+
+        # Test hierarchical lookup
+        assert get_target_case_for_element("field", "object", config) == "camelCase"
+        assert get_target_case_for_element("field", "interface", config) == "snake_case"
+
+        # Test direct lookup
+        assert get_target_case_for_element("enumValue", "", config) == "macrocase"
+
+    def test_missing_element_type(self) -> None:
+        """Test behavior when element type is not in config."""
+        config = {"field": {"object": "camelCase"}}
+        result = get_target_case_for_element("missing", "context", config)
+        assert result is None
+
+    def test_missing_context(self) -> None:
+        """Test behavior when context is missing from hierarchical config."""
+        config = {"field": {"object": "camelCase"}}
+        result = get_target_case_for_element("field", "missing_context", config)
+        assert result is None
+
+    def test_string_config_value(self) -> None:
+        """Test when config value is a string instead of dict."""
+        config = {"enumValue": "camelCase"}
+        result = get_target_case_for_element("enumValue", "", config)
+        assert result == "camelCase"
+
+
+class TestApplyNamingToSchema:
+    """Test applying naming configuration to GraphQL schemas."""
+
+    def test_apply_naming_converts_type_names(self) -> None:
+        """Test that type names are converted in the schema type_map."""
+        enum_type = GraphQLEnumType(name="test_enum", values={"VALUE": GraphQLEnumValue("VALUE")})
+        object_type = GraphQLObjectType(name="test_object", fields={"field": GraphQLField(GraphQLString)})
+
+        query_type = GraphQLObjectType(name="Query", fields={"test": GraphQLField(object_type)})
+        schema = GraphQLSchema(query=query_type, types=[object_type, enum_type])
+
+        naming_config = {"type": {"object": "PascalCase", "enum": "PascalCase"}}
+
+        converted_schema = apply_naming_to_schema(schema, naming_config)
+
+        assert "TestObject" in converted_schema.type_map
+        assert "TestEnum" in converted_schema.type_map
+        assert "test_object" not in converted_schema.type_map
+        assert "test_enum" not in converted_schema.type_map
+
+        assert converted_schema.type_map["TestObject"].name == "TestObject"
+        assert converted_schema.type_map["TestEnum"].name == "TestEnum"
+
+    def test_apply_naming_preserves_builtin_types(self) -> None:
+        """Test that built-in GraphQL types are not modified."""
+        object_type = GraphQLObjectType(name="TestObject", fields={"field": GraphQLField(GraphQLString)})
+        query_type = GraphQLObjectType(name="Query", fields={"test": GraphQLField(object_type)})
+        schema = GraphQLSchema(query=query_type, types=[object_type])
+
+        naming_config = {"type": {"object": "snake_case"}}
+        converted_schema = apply_naming_to_schema(schema, naming_config)
+
+        # Built-in types should remain unchanged
+        builtin_types = ["String", "Int", "Float", "Boolean", "ID", "Query", "Mutation", "Subscription"]
+        for builtin in builtin_types:
+            if builtin in schema.type_map:
+                assert builtin in converted_schema.type_map
+                assert converted_schema.type_map[builtin].name == builtin
+
+    def test_apply_naming_converts_fields_and_enums_end_to_end(self) -> None:
+        """Test complete schema conversion with types, fields, and enum values."""
+        enum_type = GraphQLEnumType(name="test_enum", values={"OLD_VALUE": GraphQLEnumValue("OLD_VALUE")})
+
+        object_type = GraphQLObjectType(
+            name="test_object", fields={"TestField": GraphQLField(GraphQLString), "enum_field": GraphQLField(enum_type)}
+        )
+
+        query_type = GraphQLObjectType(name="Query", fields={"test": GraphQLField(object_type)})
+        schema = GraphQLSchema(query=query_type, types=[object_type, enum_type])
+
+        naming_config = {
+            "type": {"object": "PascalCase", "enum": "PascalCase"},
+            "field": {"object": "camelCase"},
+            "enumValue": "PascalCase",
+        }
+
+        converted_schema = apply_naming_to_schema(schema, naming_config)
+
+        assert "TestObject" in converted_schema.type_map
+        assert "TestEnum" in converted_schema.type_map
+
+        test_object_type = converted_schema.type_map["TestObject"]
+        assert isinstance(test_object_type, GraphQLObjectType)
+        assert "testField" in test_object_type.fields
+        assert "enumField" in test_object_type.fields
+        assert "TestField" not in test_object_type.fields
+        assert "enum_field" not in test_object_type.fields
+
+        test_enum_type = converted_schema.type_map["TestEnum"]
+        assert isinstance(test_enum_type, GraphQLEnumType)
+        assert "OldValue" in test_enum_type.values
+        assert "OLD_VALUE" not in test_enum_type.values
+
+    def test_empty_naming_config_preserves_schema(self) -> None:
+        """Test that empty config leaves schema unchanged."""
+        object_type = GraphQLObjectType(name="TestObject", fields={"TestField": GraphQLField(GraphQLString)})
+        query_type = GraphQLObjectType(name="Query", fields={"test": GraphQLField(object_type)})
+        original_schema = GraphQLSchema(query=query_type, types=[object_type])
+
+        converted_schema = apply_naming_to_schema(original_schema, {})
+
+        assert len(converted_schema.type_map) == len(original_schema.type_map)
+        assert "TestObject" in converted_schema.type_map
+        test_object_type = converted_schema.type_map["TestObject"]
+        assert isinstance(test_object_type, GraphQLObjectType)
+        assert "TestField" in test_object_type.fields
+
+
+class TestConvertFieldNames:
+    """Test field name conversion functionality - verifies GraphQL schema objects are modified."""
+
+    def test_convert_object_field_names_updates_dict_keys_and_objects(self) -> None:
+        """Test that field conversion updates both dictionary keys and field.name properties."""
+        object_type = GraphQLObjectType(
+            name="TestObject",
+            fields={"TestField": GraphQLField(GraphQLString), "AnotherTestField": GraphQLField(GraphQLString)},
+        )
+
+        naming_config = {"field": {"object": "camelCase"}}
+        convert_field_names(object_type, naming_config)
+
+        assert "testField" in object_type.fields
+        assert "anotherTestField" in object_type.fields
+        assert "TestField" not in object_type.fields
+        assert "AnotherTestField" not in object_type.fields
+
+    def test_convert_interface_field_names(self) -> None:
+        """Test field conversion works for interface types."""
+        interface_type = GraphQLInterfaceType(name="TestInterface", fields={"TestField": GraphQLField(GraphQLString)})
+
+        naming_config = {"field": {"interface": "snake_case"}}
+        convert_field_names(interface_type, naming_config)
+
+        assert "test_field" in interface_type.fields
+        assert "TestField" not in interface_type.fields
+
+    def test_convert_input_field_names(self) -> None:
+        """Test field conversion works for input types."""
+        input_type = GraphQLInputObjectType(name="TestInput", fields={"TestField": GraphQLInputField(GraphQLString)})
+
+        naming_config = {"field": {"input": "kebab-case"}}
+        convert_field_names(input_type, naming_config)
+
+        assert "test-field" in input_type.fields
+        assert "TestField" not in input_type.fields
+
+    def test_convert_argument_names(self) -> None:
+        """Test that field arguments are also converted."""
+        object_type = GraphQLObjectType(
+            name="TestObject",
+            fields={
+                "testField": GraphQLField(
+                    GraphQLString,
+                    args={"TestArg": GraphQLArgument(GraphQLString), "AnotherArg": GraphQLArgument(GraphQLString)},
+                )
+            },
+        )
+
+        naming_config = {"argument": {"field": "MACROCASE"}}
+        convert_field_names(object_type, naming_config)
+
+        field_args = object_type.fields["testField"].args
+        assert "TEST_ARG" in field_args
+        assert "ANOTHER_ARG" in field_args
+        assert "TestArg" not in field_args
+        assert "AnotherArg" not in field_args
+
+    def test_no_conversion_when_no_config(self) -> None:
+        """Test that fields remain unchanged when no config is provided."""
+        object_type = GraphQLObjectType(name="TestObject", fields={"TestField": GraphQLField(GraphQLString)})
+
+        convert_field_names(object_type, {})
+
+        assert "TestField" in object_type.fields
+
+
+class TestConvertEnumValues:
+    """Test enum value conversion functionality - verifies GraphQL schema objects are modified."""
+
+    def test_convert_enum_values_updates_dict_keys_and_objects(self) -> None:
+        """Test that enum conversion updates both dictionary keys and enum value names."""
+        enum_type = GraphQLEnumType(
+            name="TestEnum",
+            values={
+                "OLD_VALUE": GraphQLEnumValue("OLD_VALUE"),
+                "ANOTHER_OLD_VALUE": GraphQLEnumValue("ANOTHER_OLD_VALUE"),
+            },
+        )
+
+        naming_config = {"enumValue": "PascalCase"}
+        convert_enum_values(enum_type, naming_config)
+
+        assert "OldValue" in enum_type.values
+        assert "AnotherOldValue" in enum_type.values
+        assert "OLD_VALUE" not in enum_type.values
+        assert "ANOTHER_OLD_VALUE" not in enum_type.values
+
+    def test_enum_conversion_preserves_other_properties(self) -> None:
+        """Test that other enum value properties are preserved during conversion."""
+        enum_value = GraphQLEnumValue("OLD_VALUE", description="Test description")
+        enum_type = GraphQLEnumType(name="TestEnum", values={"OLD_VALUE": enum_value})
+
+        naming_config = {"enumValue": "camelCase"}
+        convert_enum_values(enum_type, naming_config)
+
+        converted_value = enum_type.values["oldValue"]
+        assert converted_value.description == "Test description"
+
+    def test_no_conversion_when_no_config(self) -> None:
+        """Test that enum values remain unchanged when no config is provided."""
+        enum_type = GraphQLEnumType(name="TestEnum", values={"OLD_VALUE": GraphQLEnumValue("OLD_VALUE")})
+
+        convert_enum_values(enum_type, {})
+
+        assert "OLD_VALUE" in enum_type.values
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -212,6 +212,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d2/1c/2f26665d4be4f1b82b2dfe46f3bd7901582863ddf1bd597309b5d0a5e6d4/bump_my_version-1.2.1.tar.gz", hash = "sha256:96c48f880c149c299312f983d06b50e0277ffc566e64797bf3a6c240bce2dfcc", size = 1137281, upload-time = "2025-07-19T11:52:03.235Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5c/f4/40db87f649d9104c5fe69706cc455e24481b90024b2aacb64cc0ef205536/bump_my_version-1.2.1-py3-none-any.whl", hash = "sha256:ddb41d5f30abdccce9d2dc873e880bdf04ec8c7e7237c73a4c893aa10b7d7587", size = 59567, upload-time = "2025-07-19T11:52:01.343Z" },
+]
+
+[[package]]
+name = "case-converter"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/09/f5b4cf1f5da361e7c6f5f5f5d8bbf313a57d01574194f84abed68447fbb6/case_converter-1.2.0.tar.gz", hash = "sha256:4e0281ae60d4335e57300bafd61cfb3fa65734587fe9efd32f6cec1a506685c5", size = 8760, upload-time = "2025-02-19T16:49:34.891Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/8e/32a7ab1ac97de46e6a0d45b1fcfe1ad7ba9a523a6fb449662ccf39b9591e/case_converter-1.2.0-py3-none-any.whl", hash = "sha256:bb5bc6b1e121c394a6de6526cd3f8be0f5c5817c40d32251cce28a2cf4a72d8c", size = 16250, upload-time = "2025-02-19T16:49:30.48Z" },
 ]
 
 [[package]]
@@ -2165,6 +2174,7 @@ name = "s2dm"
 source = { editable = "." }
 dependencies = [
     { name = "ariadne" },
+    { name = "case-converter" },
     { name = "click" },
     { name = "graphql-core" },
     { name = "langcodes" },
@@ -2195,6 +2205,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "ariadne", specifier = ">=0.24.0" },
+    { name = "case-converter", specifier = ">=1.2.0" },
     { name = "click", specifier = ">=8.1.7" },
     { name = "graphql-core", specifier = ">=3.2.6" },
     { name = "langcodes", specifier = ">=3.5.0" },


### PR DESCRIPTION
This PR implements #21.

Usage:

```shell
s2dm export --naming-config naming_config.yaml ...
```

Naming Config:

```yaml
type:
  object: PascalCase
field:
  object: PascalCase

```

Input GraphQL:

```graphql
type vehicle {
  speed: Int
}
```

Output JSON:

```json
{
  "$schema": "https://json-schema.org/draft/2020-12/schema",
  "$defs": {
    "Vehicle": {
      "additionalProperties": false,
      "properties": {
        "Speed": {
          "type": "integer"
        }
      },
      "type": "object"
    }
  },
  "title": "Vehicle",
  "$ref": "#/$defs/Vehicle"
}
```