### PR TITLE
feat(export): implement naming conversion in the export command

### DIFF
--- a/docs-gen/content/docs/tools/cli.md
+++ b/docs-gen/content/docs/tools/cli.md
@@ -3,4 +3,128 @@ title: Command Line Interface (CLI)
 weight: 1
 chapter: false
 ---
-Under construction...
+
+## Export Commands
+
+### Naming Configuration
+
+All export commands support a global naming configuration feature that allows you to transform element names during the export process using the `[--naming-config | -n]` flag.
+
+Apply naming configuration to any export command:
+
+```bash
+s2dm export [--naming-config | -n] naming.yaml ...
+```
+
+#### Configuration Format
+
+The naming configuration is defined in a YAML file with the following structure:
+
+```yaml
+# Transform type names by type context
+type:
+  object: PascalCase
+  interface: PascalCase
+  input: PascalCase
+  enum: PascalCase
+  union: PascalCase
+  scalar: PascalCase
+
+# Transform field names by type context
+field:
+  object: camelCase
+  interface: camelCase
+  input: snake_case
+
+# Transform enum values (no context needed)
+enumValue: MACROCASE
+
+# Transform instanceTag field names (no context needed)
+instanceTag: COBOL-CASE
+
+# Transform argument names by context
+argument:
+  field: camelCase
+```
+
+#### Supported Case Formats
+
+The naming configuration supports the following case conversion formats:
+
+- **camelCase**: `myVariableName`
+- **PascalCase**: `MyVariableName`
+- **snake_case**: `my_variable_name`
+- **kebab-case**: `my-variable-name`
+- **MACROCASE**: `MY_VARIABLE_NAME`
+- **COBOL-CASE**: `MY-VARIABLE-NAME`
+- **flatcase**: `myvariablename`
+- **TitleCase**: `My Variable Name`
+
+#### Example Conversion
+
+Given this GraphQL schema:
+
+```graphql
+type vehicle_info {
+  avg_speed: Float
+  fuel_type: fuel_type_enum
+}
+
+enum fuel_type_enum {
+  GASOLINE_TYPE
+  DIESEL_TYPE
+}
+```
+
+And this naming configuration:
+
+```yaml
+type:
+  object: PascalCase
+  enum: PascalCase
+field:
+  object: camelCase
+enumValue: PascalCase
+```
+
+The exported schema will transform names as follows:
+
+- Type: `vehicle_info` → `VehicleInfo`
+- Field: `avg_speed` → `avgSpeed`
+- Field: `fuel_type` → `fuelType`
+- Enum type: `fuel_type_enum` → `FuelTypeEnum`
+- Enum values: `GASOLINE_TYPE` → `GasolineType`, `DIESEL_TYPE` → `DieselType`
+
+#### Validation Rules
+
+The naming configuration system enforces several validation rules to ensure consistency and correctness:
+
+**Element Type Validation:**
+
+- **Valid element types**: Only `type`, `field`, `argument`, `enumValue`, and `instanceTag` are allowed
+- **Context restrictions**: Some element types cannot have context-specific configurations:
+  - `enumValue` and `instanceTag` are contextless and use a single case format
+  - `argument` can only have `field` context
+- **Value type validation**: Element values must be either strings (case formats) or dictionaries (for context-specific configurations)
+
+**Context Validation:**
+
+- **Type contexts**: `object`, `interface`, `input`, `scalar`, `union`, `enum`
+- **Field contexts**: `object`, `interface`, `input`
+- **Argument contexts**: `field`
+
+**Case Format Validation:**
+
+- **Valid case formats**: `camelCase`, `PascalCase`, `snake_case`, `kebab-case`, `MACROCASE`, `COBOL-CASE`, `flatcase`, `TitleCase`
+- **Format enforcement**: Only recognized case formats are accepted; invalid formats will cause validation errors
+
+**Special Rules:**
+
+- **EnumValue-InstanceTag pairing**: If `enumValue` is present in the configuration, `instanceTag` must also be present
+- **InstanceTag preservation**: The literal field name `instanceTag` is never transformed, regardless of naming configuration, to preserve its semantic meaning
+
+#### Notes
+
+- Built-in GraphQL types (`String`, `Int`, `Float`, `Boolean`, `ID`, `Query`, `Mutation`, `Subscription`) are never transformed
+- If a configuration is not provided for an element type, the original names are preserved
+- Configuration is loaded once at the command level and applied consistently across the entire export process

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "pyshacl>=0.30.0",
     "ariadne>=0.24.0",
     "langcodes>=3.5.0",
+    "case-converter>=1.2.0",
 ]
 requires-python = ">=3.11"
 

--- a/src/s2dm/exporters/README.md
+++ b/src/s2dm/exporters/README.md
@@ -649,6 +649,131 @@ You can call the help for usage reference:
 s2dm export jsonschema --help
 ```
 
+## Naming Configuration
+
+All export commands support a global naming configuration feature that allows you to transform element names during the export process using the `[--naming-config | -n]` flag.
+
+### Usage
+
+Apply naming configuration to any export command:
+
+```bash
+s2dm export [--naming-config | -n] naming.yaml ...
+```
+
+### Configuration Format
+
+The naming configuration is defined in a YAML file with the following structure:
+
+```yaml
+# Transform type names by type context
+type:
+  object: PascalCase
+  interface: PascalCase
+  input: PascalCase
+  enum: PascalCase
+  union: PascalCase
+  scalar: PascalCase
+
+# Transform field names by type context
+field:
+  object: camelCase
+  interface: camelCase
+  input: snake_case
+
+# Transform enum values (no context needed)
+enumValue: MACROCASE
+
+# Transform instanceTag field names (no context needed)
+instanceTag: COBOL-CASE
+
+# Transform argument names by context
+argument:
+  field: camelCase
+```
+
+### Supported Case Formats
+
+The naming configuration supports the following case conversion formats:
+
+- **camelCase**: `myVariableName`
+- **PascalCase**: `MyVariableName`
+- **snake_case**: `my_variable_name`
+- **kebab-case**: `my-variable-name`
+- **MACROCASE**: `MY_VARIABLE_NAME`
+- **COBOL-CASE**: `MY-VARIABLE-NAME`
+- **flatcase**: `myvariablename`
+- **TitleCase**: `My Variable Name`
+
+### Example Conversion
+
+Given this GraphQL schema:
+
+```graphql
+type vehicle_info {
+  avg_speed: Float
+  fuel_type: fuel_type_enum
+}
+
+enum fuel_type_enum {
+  GASOLINE_TYPE
+  DIESEL_TYPE
+}
+```
+
+And this naming configuration:
+
+```yaml
+type:
+  object: PascalCase
+  enum: PascalCase
+field:
+  object: camelCase
+enumValue: PascalCase
+```
+
+The exported schema will transform names as follows:
+
+- Type: `vehicle_info` → `VehicleInfo`
+- Field: `avg_speed` → `avgSpeed`
+- Field: `fuel_type` → `fuelType`
+- Enum type: `fuel_type_enum` → `FuelTypeEnum`
+- Enum values: `GASOLINE_TYPE` → `GasolineType`, `DIESEL_TYPE` → `DieselType`
+
+### Validation Rules
+
+The naming configuration system enforces several validation rules to ensure consistency and correctness:
+
+#### Element Type Validation
+
+- **Valid element types**: Only `type`, `field`, `argument`, `enumValue`, and `instanceTag` are allowed
+- **Context restrictions**: Some element types cannot have context-specific configurations:
+  - `enumValue` and `instanceTag` are contextless and use a single case format
+  - `argument` can only have `field` context
+- **Value type validation**: Element values must be either strings (case formats) or dictionaries (for context-specific configurations)
+
+#### Context Validation
+
+- **Type contexts**: `object`, `interface`, `input`, `scalar`, `union`, `enum`
+- **Field contexts**: `object`, `interface`, `input`
+- **Argument contexts**: `field`
+
+#### Case Format Validation
+
+- **Valid case formats**: `camelCase`, `PascalCase`, `snake_case`, `kebab-case`, `MACROCASE`, `COBOL-CASE`, `flatcase`, `TitleCase`
+- **Format enforcement**: Only recognized case formats are accepted; invalid formats will cause validation errors
+
+#### Special Rules
+
+- **EnumValue-InstanceTag pairing**: If `enumValue` is present in the configuration, `instanceTag` must also be present
+- **InstanceTag preservation**: The literal field name `instanceTag` is never transformed, regardless of naming configuration, to preserve its semantic meaning
+
+### Notes
+
+- Built-in GraphQL types (`String`, `Int`, `Float`, `Boolean`, `ID`, `Query`, `Mutation`, `Subscription`) are never transformed
+- If a configuration is not provided for an element type, the original names are preserved
+- Configuration is loaded once at the command level and applied consistently across the entire export process
+
 ## Identifiers
 With the asumption that specification files will be hosted in a certain Git repository, the tools include functions to support the proper identification of concepts and their metadata to facilite their evolution.
 The identification process is based on the following principles, which are describes in the rest of this subsection:

--- a/src/s2dm/exporters/jsonschema/jsonschema.py
+++ b/src/s2dm/exporters/jsonschema/jsonschema.py
@@ -1,16 +1,21 @@
 import json
 from pathlib import Path
+from typing import Any
 
 from graphql import GraphQLSchema
 
 from s2dm import log
-from s2dm.exporters.utils import load_schema
+from s2dm.exporters.utils import load_schema_with_naming
 
 from .transformer import JsonSchemaTransformer
 
 
 def transform(
-    graphql_schema: GraphQLSchema, root_type: str | None = None, strict: bool = False, expanded_instances: bool = False
+    graphql_schema: GraphQLSchema,
+    root_type: str | None = None,
+    strict: bool = False,
+    expanded_instances: bool = False,
+    naming_config: dict[str, Any] | None = None,
 ) -> str:
     """
     Transform a GraphQL schema object to JSON Schema format.
@@ -20,6 +25,7 @@ def transform(
         root_type: Optional root type name for the JSON schema
         strict: Enforce strict field nullability translation from GraphQL to JSON Schema
         expanded_instances: Expand instance tags into nested structure instead of arrays
+        naming_config: Optional naming configuration for instance tag expansion
 
     Returns:
         str: JSON Schema representation as a string
@@ -31,7 +37,7 @@ def transform(
             raise ValueError(f"Root type '{root_type}' not found in schema")
         log.info(f"Using root type: {root_type}")
 
-    transformer = JsonSchemaTransformer(graphql_schema, root_type, strict, expanded_instances)
+    transformer = JsonSchemaTransformer(graphql_schema, root_type, strict, expanded_instances, naming_config)
     json_schema = transformer.transform()
 
     json_schema_str = json.dumps(json_schema, indent=2)
@@ -42,7 +48,11 @@ def transform(
 
 
 def translate_to_jsonschema(
-    schema_path: Path, root_type: str | None = None, strict: bool = False, expanded_instances: bool = False
+    schema_path: Path,
+    root_type: str | None = None,
+    strict: bool = False,
+    expanded_instances: bool = False,
+    naming_config: dict[str, Any] | None = None,
 ) -> str:
     """
     Translate a GraphQL schema file to JSON Schema format.
@@ -58,7 +68,7 @@ def translate_to_jsonschema(
     """
     log.info(f"Loading GraphQL schema from: {schema_path}")
 
-    graphql_schema = load_schema(schema_path)
+    graphql_schema = load_schema_with_naming(schema_path, naming_config)
     log.info(f"Successfully loaded GraphQL schema with {len(graphql_schema.type_map)} types")
 
-    return transform(graphql_schema, root_type, strict, expanded_instances)
+    return transform(graphql_schema, root_type, strict, expanded_instances, naming_config)

--- a/src/s2dm/exporters/jsonschema/transformer.py
+++ b/src/s2dm/exporters/jsonschema/transformer.py
@@ -63,11 +63,13 @@ class JsonSchemaTransformer:
         root_type: str | None = None,
         strict: bool = False,
         expanded_instances: bool = False,
+        naming_config: dict[str, Any] | None = None,
     ):
         self.graphql_schema = graphql_schema
         self.root_type = root_type
         self.strict = strict
         self.expanded_instances = expanded_instances
+        self.naming_config = naming_config
 
     def transform(self) -> dict[str, Any]:
         """
@@ -375,7 +377,7 @@ class JsonSchemaTransformer:
         if is_object_type(named_type):
             instance_tag_object = get_instance_tag_object(cast(GraphQLObjectType, named_type), self.graphql_schema)
             if instance_tag_object:
-                expanded_instance_tag = expand_instance_tag(instance_tag_object)
+                expanded_instance_tag = expand_instance_tag(instance_tag_object, self.naming_config)
 
                 definition: dict[str, Any] = {
                     "additionalProperties": False,
@@ -422,7 +424,7 @@ class JsonSchemaTransformer:
         Returns:
             Dict[str, Any]: JSON Schema definition with expanded nested structure
         """
-        expanded_instance_tags = expand_instance_tag(instance_tag_object)
+        expanded_instance_tags = expand_instance_tag(instance_tag_object, self.naming_config)
 
         definition: dict[str, Any] = {
             "additionalProperties": False,

--- a/src/s2dm/exporters/naming_utils.py
+++ b/src/s2dm/exporters/naming_utils.py
@@ -1,0 +1,214 @@
+from typing import Any
+
+from caseconverter import camelcase, cobolcase, flatcase, kebabcase, macrocase, pascalcase, snakecase, titlecase
+from graphql import (
+    GraphQLEnumType,
+    GraphQLInputObjectType,
+    GraphQLInterfaceType,
+    GraphQLObjectType,
+    GraphQLScalarType,
+    GraphQLSchema,
+    GraphQLUnionType,
+    get_named_type,
+)
+
+CASE_CONVERTERS = {
+    "camelCase": camelcase,
+    "PascalCase": pascalcase,
+    "snake_case": snakecase,
+    "kebab-case": kebabcase,
+    "MACROCASE": macrocase,
+    "COBOL-CASE": cobolcase,
+    "flatcase": flatcase,
+    "TitleCase": titlecase,
+}
+
+TYPE_CONTEXTS = {
+    GraphQLObjectType: "object",
+    GraphQLInterfaceType: "interface",
+    GraphQLInputObjectType: "input",
+    GraphQLEnumType: "enum",
+    GraphQLUnionType: "union",
+    GraphQLScalarType: "scalar",
+}
+
+
+def convert_name(name: str, target_case: str) -> str:
+    """Convert a name to the specified case format.
+
+    Args:
+        name: The name to convert
+        target_case: The target case format (e.g., "camelCase", "PascalCase", "snake_case")
+
+    Returns:
+        The converted name, or the original name if target_case is not supported
+    """
+    if target_case in CASE_CONVERTERS:
+        return str(CASE_CONVERTERS[target_case](name))
+    return name
+
+
+def get_target_case_for_element(element_type: str, context: str, naming_config: dict[str, Any]) -> str | None:
+    """Get the target case conversion for a specific element type and context.
+
+    Args:
+        element_type: The type of element (e.g., "type", "field", "enumValue", "argument")
+        context: The context within the element type (e.g., "object", "interface", "input")
+        naming_config: Configuration dictionary specifying case conversions
+
+    Returns:
+        The target case string (e.g., "camelCase", "PascalCase") or None if not configured
+    """
+    if element_type in naming_config:
+        config_section = naming_config[element_type]
+        if isinstance(config_section, dict) and context in config_section:
+            return str(config_section[context])
+        elif isinstance(config_section, str):
+            return str(config_section)
+    return None
+
+
+def apply_naming_to_schema(schema: GraphQLSchema, naming_config: dict[str, Any]) -> None:
+    """Apply naming conversion to a GraphQL schema by modifying it in place.
+
+    Args:
+        schema: The GraphQL schema to modify
+        naming_config: Configuration dictionary specifying case conversions for different element types
+    """
+
+    from s2dm.exporters.utils import is_built_in_type
+
+    types_to_rename = []
+    for type_name, type_obj in schema.type_map.items():
+        if is_built_in_type(type_name):
+            continue
+
+        context = TYPE_CONTEXTS.get(type(type_obj))
+        if context:
+            target_case = get_target_case_for_element("type", context, naming_config)
+            if target_case:
+                new_name = convert_name(type_name, target_case)
+                if new_name != type_name:
+                    types_to_rename.append((type_name, new_name, type_obj))
+
+        if isinstance(type_obj, GraphQLObjectType | GraphQLInterfaceType | GraphQLInputObjectType):
+            convert_field_names(type_obj, naming_config, schema)
+        elif isinstance(type_obj, GraphQLEnumType):
+            convert_enum_values(type_obj, naming_config)
+
+    for old_name, new_name, type_obj in types_to_rename:
+        del schema.type_map[old_name]
+        type_obj.name = new_name
+        schema.type_map[new_name] = type_obj
+
+
+def is_instance_tag_field(field_name: str, field: Any, schema: GraphQLSchema) -> bool:
+    """Check if a field is an instanceTag field that should not be renamed.
+
+    Args:
+        field_name: Name of the field to check
+        field: The GraphQL field object
+        schema: The GraphQL schema containing the field's type
+
+    Returns:
+        True if this is an instanceTag field that should preserve its name
+    """
+    if field_name != "instanceTag":
+        return False
+
+    field_type = get_named_type(field.type)
+    target_type = schema.get_type(field_type.name)
+
+    if not isinstance(target_type, GraphQLObjectType):
+        return False
+
+    if target_type.ast_node and target_type.ast_node.directives:
+        for directive in target_type.ast_node.directives:
+            if directive.name.value == "instanceTag":
+                return True
+    return False
+
+
+def convert_field_names(
+    type_obj: GraphQLObjectType | GraphQLInterfaceType | GraphQLInputObjectType,
+    naming_config: dict[str, Any],
+    schema: GraphQLSchema,
+) -> None:
+    """Convert field names and argument names for a GraphQL type object.
+
+    Args:
+        type_obj: The GraphQL type object to modify
+        naming_config: Configuration dictionary specifying case conversions
+        schema: The GraphQL schema (used for instanceTag field detection)
+    """
+    context = TYPE_CONTEXTS.get(type(type_obj))
+    if not context:
+        return
+
+    target_case = get_target_case_for_element("field", context, naming_config)
+    if target_case:
+        new_fields = {}
+        for old_name, field in type_obj.fields.items():
+            if is_instance_tag_field(old_name, field, schema):
+                new_fields[old_name] = field
+            else:
+                new_name = convert_name(old_name, target_case)
+                new_fields[new_name] = field
+
+        type_obj.fields.clear()
+        type_obj.fields.update(new_fields)
+
+    if context in ("object", "interface"):
+        for field in type_obj.fields.values():
+            if hasattr(field, "args") and field.args:
+                # Convert argument names - need to update dictionary keys (args don't have .name attribute)
+                arg_target_case = get_target_case_for_element("argument", "field", naming_config)
+                if arg_target_case:
+                    new_args = {}
+                    for old_name, arg in field.args.items():
+                        new_name = convert_name(old_name, arg_target_case)
+                        new_args[new_name] = arg
+
+                    # Replace the args dictionary
+                    field.args.clear()
+                    field.args.update(new_args)
+
+
+def convert_enum_values(type_obj: GraphQLEnumType, naming_config: dict[str, Any]) -> None:
+    """Convert enum value names for a GraphQL enum type.
+
+    Args:
+        type_obj: The GraphQL enum type to modify
+        naming_config: Configuration dictionary specifying case conversions
+    """
+    target_case = get_target_case_for_element("enumValue", "", naming_config)
+    if not target_case:
+        return
+
+    new_values = {}
+    for old_name, enum_value in type_obj.values.items():
+        new_name = convert_name(old_name, target_case)
+        new_values[new_name] = enum_value
+
+    type_obj.values.clear()
+    type_obj.values.update(new_values)
+
+
+def apply_naming_to_instance_values(instance_values: list[str], naming_config: dict[str, Any] | None) -> list[str]:
+    """Apply naming conversion to instance tag values based on the naming configuration.
+
+    Args:
+        instance_values: List of enum values to convert
+        naming_config: Naming configuration dictionary
+
+    Returns:
+        List of converted enum values
+    """
+    if not naming_config:
+        return instance_values
+
+    target_case = get_target_case_for_element("instanceTag", "", naming_config)
+    if not target_case:
+        return instance_values
+
+    return [convert_name(value, target_case) for value in instance_values]

--- a/src/s2dm/exporters/shacl.py
+++ b/src/s2dm/exporters/shacl.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from pathlib import Path
-from typing import cast
+from typing import Any, cast
 
 from graphql import (
     GraphQLEnumType,
@@ -25,7 +25,7 @@ from s2dm.exporters.utils import (
     get_instance_tag_object,
     has_directive,
     has_valid_instance_tag_field,
-    load_schema,
+    load_schema_with_naming,
     print_field_sdl,
 )
 
@@ -66,6 +66,7 @@ def translate_to_shacl(
     shapes_namespace_prefix: str,
     model_namespace: str,
     model_namespace_prefix: str,
+    naming_config: dict[str, Any] | None = None,
 ) -> Graph:
     """Translate a GraphQL schema to SHACL."""
     namespaces = Namespaces(
@@ -74,7 +75,7 @@ def translate_to_shacl(
         Namespace(model_namespace),
         Namespace(model_namespace_prefix),
     )
-    schema = load_schema(schema_path)
+    schema = load_schema_with_naming(schema_path, naming_config)
     graph = Graph()
     graph.bind(namespaces.shapes_prefix, namespaces.shapes)
     graph.bind(namespaces.model_prefix, namespaces.model)
@@ -89,13 +90,17 @@ def translate_to_shacl(
         if has_directive(object_type, "instanceTag"):
             log.debug(f"Skipping object type '{object_type.name}' with directive 'instanceTag'.")
             continue
-        process_object_type(namespaces, object_type, graph, schema)
+        process_object_type(namespaces, object_type, graph, schema, naming_config)
 
     return graph
 
 
 def process_object_type(
-    namespaces: Namespaces, object_type: GraphQLObjectType, graph: Graph, schema: GraphQLSchema
+    namespaces: Namespaces,
+    object_type: GraphQLObjectType,
+    graph: Graph,
+    schema: GraphQLSchema,
+    naming_config: dict[str, Any] | None = None,
 ) -> None:
     """Process a GraphQL object type and generate the corresponding SHACL triples."""
     log.info(f"Processing object type '{object_type.name}'.")
@@ -107,7 +112,7 @@ def process_object_type(
         _ = graph.add((shape_node, SH.description, Literal(object_type.description)))
 
     for field_name, field in object_type.fields.items():
-        process_field(namespaces, field_name, field, shape_node, graph, schema)
+        process_field(namespaces, field_name, field, shape_node, graph, schema, naming_config)
 
 
 def create_property_shape_with_literal(
@@ -189,6 +194,7 @@ def process_field(
     shape_node: URIRef,
     graph: Graph,
     schema: GraphQLSchema,
+    naming_config: dict[str, Any] | None = None,
 ) -> None:
     """Process a field of a GraphQL object type and generate the corresponding SHACL triples."""
     log.info(f"Processing field... '{print_field_sdl(field)}'")
@@ -269,7 +275,7 @@ def process_field(
                 if has_valid_instance_tag_field(object_type=unwrapped_field_type, schema=schema):
                     instance_tag_object = get_instance_tag_object(unwrapped_field_type, schema)
                     if instance_tag_object is not None:
-                        expanded_tags = expand_instance_tag(instance_tag_object)
+                        expanded_tags = expand_instance_tag(instance_tag_object, naming_config)
                         for tag in expanded_tags:
                             create_property_shape_with_iri(
                                 namespaces=namespaces,

--- a/src/s2dm/exporters/vspec.py
+++ b/src/s2dm/exporters/vspec.py
@@ -14,6 +14,7 @@ from graphql import (
 )
 
 from s2dm import log
+from s2dm.exporters.naming_utils import apply_naming_to_instance_values
 from s2dm.exporters.utils import (
     FieldCase,
     get_all_expanded_instance_tags,
@@ -22,7 +23,7 @@ from s2dm.exporters.utils import (
     get_instance_tag_dict,
     get_instance_tag_object,
     has_directive,
-    load_schema,
+    load_schema_with_naming,
 )
 
 UNITS_DICT = {  # TODO: move to a separate file or use the vss tools to get the mapping directly from dynamic_units
@@ -161,9 +162,9 @@ class CustomDumper(yaml.Dumper):
 CustomDumper.add_representer(list, CustomDumper.represent_list)
 
 
-def translate_to_vspec(schema_path: Path) -> str:
+def translate_to_vspec(schema_path: Path, naming_config: dict[str, Any] | None = None) -> str:
     """Translate a GraphQL schema to YAML."""
-    schema = load_schema(schema_path)
+    schema = load_schema_with_naming(schema_path, naming_config)
 
     all_object_types = get_all_object_types(schema)
     log.debug(f"Object types: {all_object_types}")
@@ -182,14 +183,14 @@ def translate_to_vspec(schema_path: Path) -> str:
 
         # Add a VSS branch structure for the object type
         if object_type.name not in yaml_dict:
-            yaml_dict.update(process_object_type(object_type, schema))
+            yaml_dict.update(process_object_type(object_type, schema, naming_config))
         else:
             # TODO: Check if the processed object type is already in the yaml_dict
             log.debug(f"Object type '{object_type.name}' already exists in the YAML dictionary. Skipping.")
         # Process the fields of the object type
         for field_name, field in object_type.fields.items():
             # Add a VSS leaf structure for the field
-            field_result = process_field(field_name, field, object_type, schema, nested_types)
+            field_result = process_field(field_name, field, object_type, schema, nested_types, naming_config)
             if field_result is not None:
                 yaml_dict.update(field_result)
             else:
@@ -214,7 +215,9 @@ def translate_to_vspec(schema_path: Path) -> str:
     return yaml.dump(yaml_dict, default_flow_style=False, Dumper=CustomDumper, sort_keys=True)
 
 
-def process_object_type(object_type: GraphQLObjectType, schema: GraphQLSchema) -> dict[str, dict[str, Any]]:
+def process_object_type(
+    object_type: GraphQLObjectType, schema: GraphQLSchema, naming_config: dict[str, Any] | None = None
+) -> dict[str, dict[str, Any]]:
     """Process a GraphQL object type and generate the corresponding YAML."""
     log.info(f"Processing object type '{object_type.name}'.")
 
@@ -227,7 +230,12 @@ def process_object_type(object_type: GraphQLObjectType, schema: GraphQLSchema) -
     instance_tag_object = get_instance_tag_object(object_type, schema)
     if instance_tag_object:
         log.debug(f"Object type '{object_type.name}' has instance tag '{instance_tag_object}'.")
-        obj_dict["instances"] = list(get_instance_tag_dict(instance_tag_object).values())
+        instance_dict = get_instance_tag_dict(instance_tag_object)
+        converted_instances = []
+        for values in instance_dict.values():
+            converted_values = apply_naming_to_instance_values(values, naming_config)
+            converted_instances.append(converted_values)
+        obj_dict["instances"] = converted_instances
     else:
         log.debug(f"Object type '{object_type.name}' does not have an instance tag.")
 
@@ -240,6 +248,7 @@ def process_field(
     object_type: GraphQLObjectType,
     schema: GraphQLSchema,
     nested_types: list[tuple[str, str]],
+    naming_config: dict[str, Any] | None = None,
 ) -> dict[str, dict[str, Any]]:
     """Process a GraphQL field and generate the corresponding YAML."""
     log.info(f"Processing field '{field_name}'.")
@@ -312,7 +321,7 @@ def process_field(
         log.debug(f"Nested structure found: {object_type.name}.{output_type}(for field {field_name})")
         named_type = get_named_type(field.type)
         if isinstance(named_type, GraphQLObjectType):
-            return process_object_type(named_type, schema)  # Nested object type, process it recursively
+            return process_object_type(named_type, schema, naming_config)  # Nested object type, process it recursively
         else:
             log.debug(f"Skipping nested type '{named_type}' as it is not a GraphQLObjectType.")
             return {}

--- a/tests/test_cli_validation.py
+++ b/tests/test_cli_validation.py
@@ -1,0 +1,118 @@
+import tempfile
+from pathlib import Path
+
+import pytest
+import rich_click as click
+
+from s2dm.cli import load_naming_config, validate_naming_config
+
+
+class TestValidateNamingConfig:
+    def test_valid_config_mixed(self) -> None:
+        config = {
+            "type": "PascalCase",
+            "field": {"object": "camelCase", "interface": "camelCase"},
+            "enumValue": "PascalCase",
+            "instanceTag": "COBOL-CASE",
+        }
+        validate_naming_config(config)
+
+    def test_invalid_element_type(self) -> None:
+        config = {"invalid_element": "PascalCase"}
+        with pytest.raises(click.ClickException, match="Invalid element type 'invalid_element'"):
+            validate_naming_config(config)
+
+    def test_invalid_case_type(self) -> None:
+        config = {"type": "InvalidCase"}
+        with pytest.raises(click.ClickException, match="Invalid case type for 'type': 'InvalidCase'"):
+            validate_naming_config(config)
+
+    def test_invalid_context(self) -> None:
+        config = {"type": {"invalid_context": "PascalCase"}}
+        with pytest.raises(click.ClickException, match="Invalid context 'invalid_context' for 'type'"):
+            validate_naming_config(config)
+
+    def test_invalid_value_type(self) -> None:
+        config = {"type": 123}
+        with pytest.raises(click.ClickException, match="Invalid value type for 'type'. Expected string or dict"):
+            validate_naming_config(config)
+
+    def test_enum_value_without_instance_tag(self) -> None:
+        config = {"enumValue": "PascalCase"}
+        with pytest.raises(click.ClickException, match="If 'enumValue' is present, 'instanceTag' must also be present"):
+            validate_naming_config(config)
+
+    def test_instance_tag_without_enum_value_is_valid(self) -> None:
+        config = {"instanceTag": "COBOL-CASE"}
+        validate_naming_config(config)
+
+    def test_contextless_element_with_context(self) -> None:
+        config = {"enumValue": {"some_context": "PascalCase"}}
+        with pytest.raises(click.ClickException, match="Element type 'enumValue' cannot have contexts"):
+            validate_naming_config(config)
+
+    def test_all_valid_case_types(self) -> None:
+        valid_cases = [
+            "camelCase",
+            "PascalCase",
+            "snake_case",
+            "kebab-case",
+            "MACROCASE",
+            "COBOL-CASE",
+            "flatcase",
+            "TitleCase",
+        ]
+        for case in valid_cases:
+            config = {"instanceTag": case}
+            validate_naming_config(config)
+
+
+class TestLoadNamingConfig:
+    def test_load_valid_config_file(self) -> None:
+        config_content = """
+type:
+  object: PascalCase
+  interface: PascalCase
+field:
+  object: camelCase
+enumValue: PascalCase
+instanceTag: COBOL-CASE
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(config_content)
+            f.flush()
+
+            config = load_naming_config(Path(f.name))
+            assert config is not None
+            assert config["type"]["object"] == "PascalCase"
+            assert config["enumValue"] == "PascalCase"
+            assert config["instanceTag"] == "COBOL-CASE"
+
+        Path(f.name).unlink()
+
+    def test_load_invalid_config_file(self) -> None:
+        config_content = """
+invalid_element: PascalCase
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(config_content)
+            f.flush()
+
+            with pytest.raises(click.ClickException, match="Invalid element type 'invalid_element'"):
+                load_naming_config(Path(f.name))
+
+        Path(f.name).unlink()
+
+    def test_load_nonexistent_file(self) -> None:
+        config = load_naming_config(None)
+        assert config is None
+
+    def test_load_empty_config(self) -> None:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write("")
+            f.flush()
+
+            config = load_naming_config(Path(f.name))
+            assert config == {}
+
+        Path(f.name).unlink()

--- a/tests/test_naming_utils.py
+++ b/tests/test_naming_utils.py
@@ -1,0 +1,357 @@
+from pathlib import Path
+
+import pytest
+from graphql import (
+    GraphQLArgument,
+    GraphQLEnumType,
+    GraphQLEnumValue,
+    GraphQLField,
+    GraphQLInputField,
+    GraphQLInputObjectType,
+    GraphQLInterfaceType,
+    GraphQLObjectType,
+    GraphQLSchema,
+    GraphQLString,
+)
+
+from s2dm.exporters.naming_utils import (
+    apply_naming_to_schema,
+    convert_enum_values,
+    convert_field_names,
+    convert_name,
+    get_target_case_for_element,
+)
+from s2dm.exporters.utils import (
+    expand_instance_tag,
+    get_all_object_types,
+    get_all_objects_with_directive,
+    load_schema,
+)
+
+
+class TestConvertName:
+    """Test individual name conversion functions."""
+
+    @pytest.mark.parametrize(
+        "input_name,target_case,expected",
+        [
+            ("HelloWorld", "camelCase", "helloWorld"),
+            ("hello_world", "PascalCase", "HelloWorld"),
+            ("HelloWorld", "snake_case", "hello_world"),
+            ("hello world", "kebab-case", "hello-world"),
+            ("HelloWorld", "MACROCASE", "HELLO_WORLD"),
+            ("hello-world", "COBOL-CASE", "HELLO-WORLD"),
+            ("Hello World", "flatcase", "helloworld"),
+            ("hello_world", "TitleCase", "Hello World"),
+        ],
+    )
+    def test_convert_name_supported_cases(self, input_name: str, target_case: str, expected: str) -> None:
+        """Test conversion for all supported case formats."""
+        result = convert_name(input_name, target_case)
+        assert result == expected
+
+    def test_convert_name_unsupported_case(self) -> None:
+        """Test that unsupported cases return the original name."""
+        original = "HelloWorld"
+        result = convert_name(original, "unsupported_case")
+        assert result == original
+
+    def test_convert_name_empty_string(self) -> None:
+        """Test conversion with empty string input."""
+        result = convert_name("", "camelCase")
+        assert result == ""
+
+
+class TestGetTargetCaseForElement:
+    """Test getting target case configuration for different element types."""
+
+    def test_hierarchical_config(self) -> None:
+        """Test hierarchical configuration lookup."""
+        config = {"field": {"object": "camelCase", "interface": "snake_case"}, "enumValue": "macrocase"}
+
+        # Test hierarchical lookup
+        assert get_target_case_for_element("field", "object", config) == "camelCase"
+        assert get_target_case_for_element("field", "interface", config) == "snake_case"
+
+        # Test direct lookup
+        assert get_target_case_for_element("enumValue", "", config) == "macrocase"
+
+    def test_missing_element_type(self) -> None:
+        """Test behavior when element type is not in config."""
+        config = {"field": {"object": "camelCase"}}
+        result = get_target_case_for_element("missing", "context", config)
+        assert result is None
+
+    def test_missing_context(self) -> None:
+        """Test behavior when context is missing from hierarchical config."""
+        config = {"field": {"object": "camelCase"}}
+        result = get_target_case_for_element("field", "missing_context", config)
+        assert result is None
+
+    def test_string_config_value(self) -> None:
+        """Test when config value is a string instead of dict."""
+        config = {"enumValue": "camelCase"}
+        result = get_target_case_for_element("enumValue", "", config)
+        assert result == "camelCase"
+
+
+class TestApplyNamingToSchema:
+    """Test applying naming configuration to GraphQL schemas."""
+
+    def test_apply_naming_converts_type_names(self) -> None:
+        """Test that type names are converted in the schema type_map."""
+        enum_type = GraphQLEnumType(name="test_enum", values={"VALUE": GraphQLEnumValue("VALUE")})
+        object_type = GraphQLObjectType(name="test_object", fields={"field": GraphQLField(GraphQLString)})
+
+        query_type = GraphQLObjectType(name="Query", fields={"test": GraphQLField(object_type)})
+        schema = GraphQLSchema(query=query_type, types=[object_type, enum_type])
+
+        naming_config = {"type": {"object": "PascalCase", "enum": "PascalCase"}}
+
+        apply_naming_to_schema(schema, naming_config)
+
+        assert "TestObject" in schema.type_map
+        assert "TestEnum" in schema.type_map
+        assert "test_object" not in schema.type_map
+        assert "test_enum" not in schema.type_map
+
+        assert schema.type_map["TestObject"].name == "TestObject"
+        assert schema.type_map["TestEnum"].name == "TestEnum"
+
+    def test_apply_naming_preserves_builtin_types(self) -> None:
+        """Test that built-in GraphQL types are not modified."""
+        object_type = GraphQLObjectType(name="TestObject", fields={"field": GraphQLField(GraphQLString)})
+        query_type = GraphQLObjectType(name="Query", fields={"test": GraphQLField(object_type)})
+        schema = GraphQLSchema(query=query_type, types=[object_type])
+
+        naming_config = {"type": {"object": "snake_case"}}
+        apply_naming_to_schema(schema, naming_config)
+
+        # Built-in types should remain unchanged
+        builtin_types = ["String", "Int", "Float", "Boolean", "ID", "Query", "Mutation", "Subscription"]
+        for builtin in builtin_types:
+            if builtin in schema.type_map:
+                assert builtin in schema.type_map
+                assert schema.type_map[builtin].name == builtin
+
+    def test_apply_naming_converts_fields_and_enums_end_to_end(self) -> None:
+        """Test complete schema conversion with types, fields, and enum values."""
+        enum_type = GraphQLEnumType(name="test_enum", values={"OLD_VALUE": GraphQLEnumValue("OLD_VALUE")})
+
+        object_type = GraphQLObjectType(
+            name="test_object", fields={"TestField": GraphQLField(GraphQLString), "enum_field": GraphQLField(enum_type)}
+        )
+
+        query_type = GraphQLObjectType(name="Query", fields={"test": GraphQLField(object_type)})
+        schema = GraphQLSchema(query=query_type, types=[object_type, enum_type])
+
+        naming_config = {
+            "type": {"object": "PascalCase", "enum": "PascalCase"},
+            "field": {"object": "camelCase"},
+            "enumValue": "PascalCase",
+        }
+
+        apply_naming_to_schema(schema, naming_config)
+
+        assert "TestObject" in schema.type_map
+        assert "TestEnum" in schema.type_map
+
+        test_object_type = schema.type_map["TestObject"]
+        assert isinstance(test_object_type, GraphQLObjectType)
+        assert "testField" in test_object_type.fields
+        assert "enumField" in test_object_type.fields
+        assert "TestField" not in test_object_type.fields
+        assert "enum_field" not in test_object_type.fields
+
+        test_enum_type = schema.type_map["TestEnum"]
+        assert isinstance(test_enum_type, GraphQLEnumType)
+        assert "OldValue" in test_enum_type.values
+        assert "OLD_VALUE" not in test_enum_type.values
+
+    def test_empty_naming_config_preserves_schema(self) -> None:
+        """Test that empty config leaves schema unchanged."""
+        object_type = GraphQLObjectType(name="TestObject", fields={"TestField": GraphQLField(GraphQLString)})
+        query_type = GraphQLObjectType(name="Query", fields={"test": GraphQLField(object_type)})
+        original_schema = GraphQLSchema(query=query_type, types=[object_type])
+
+        apply_naming_to_schema(original_schema, {})
+
+        assert "TestObject" in original_schema.type_map
+        test_object_type = original_schema.type_map["TestObject"]
+        assert isinstance(test_object_type, GraphQLObjectType)
+        assert "TestField" in test_object_type.fields
+
+
+class TestConvertFieldNames:
+    """Test field name conversion functionality - verifies GraphQL schema objects are modified."""
+
+    def test_convert_object_field_names_updates_dict_keys_and_objects(self) -> None:
+        """Test that field conversion updates both dictionary keys and field.name properties."""
+        object_type = GraphQLObjectType(
+            name="TestObject",
+            fields={"TestField": GraphQLField(GraphQLString), "AnotherTestField": GraphQLField(GraphQLString)},
+        )
+
+        naming_config = {"field": {"object": "camelCase"}}
+        schema = GraphQLSchema(query=object_type)
+        convert_field_names(object_type, naming_config, schema)
+
+        assert "testField" in object_type.fields
+        assert "anotherTestField" in object_type.fields
+        assert "TestField" not in object_type.fields
+        assert "AnotherTestField" not in object_type.fields
+
+    def test_convert_interface_field_names(self) -> None:
+        """Test field conversion works for interface types."""
+        interface_type = GraphQLInterfaceType(name="TestInterface", fields={"TestField": GraphQLField(GraphQLString)})
+
+        naming_config = {"field": {"interface": "snake_case"}}
+        schema = GraphQLSchema(query=GraphQLObjectType(name="Query", fields={}))
+        convert_field_names(interface_type, naming_config, schema)
+
+        assert "test_field" in interface_type.fields
+        assert "TestField" not in interface_type.fields
+
+    def test_convert_input_field_names(self) -> None:
+        """Test field conversion works for input types."""
+        input_type = GraphQLInputObjectType(name="TestInput", fields={"TestField": GraphQLInputField(GraphQLString)})
+
+        naming_config = {"field": {"input": "kebab-case"}}
+        schema = GraphQLSchema(query=GraphQLObjectType(name="Query", fields={}))
+        convert_field_names(input_type, naming_config, schema)
+
+        assert "test-field" in input_type.fields
+        assert "TestField" not in input_type.fields
+
+    def test_convert_argument_names(self) -> None:
+        """Test that field arguments are also converted."""
+        object_type = GraphQLObjectType(
+            name="TestObject",
+            fields={
+                "testField": GraphQLField(
+                    GraphQLString,
+                    args={"TestArg": GraphQLArgument(GraphQLString), "AnotherArg": GraphQLArgument(GraphQLString)},
+                )
+            },
+        )
+
+        naming_config = {"argument": {"field": "MACROCASE"}}
+        schema = GraphQLSchema(query=object_type)
+        convert_field_names(object_type, naming_config, schema)
+
+        field_args = object_type.fields["testField"].args
+        assert "TEST_ARG" in field_args
+        assert "ANOTHER_ARG" in field_args
+        assert "TestArg" not in field_args
+        assert "AnotherArg" not in field_args
+
+    def test_no_conversion_when_no_config(self) -> None:
+        """Test that fields remain unchanged when no config is provided."""
+        object_type = GraphQLObjectType(name="TestObject", fields={"TestField": GraphQLField(GraphQLString)})
+
+        schema = GraphQLSchema(query=object_type)
+        convert_field_names(object_type, {}, schema)
+
+        assert "TestField" in object_type.fields
+
+    def test_skip_instance_tag_field_conversion(self) -> None:
+        """Test that instanceTag fields pointing to @instanceTag types are not converted."""
+        schema_path = Path(__file__).parent / "test_expanded_instances" / "test_schema.graphql"
+        schema = load_schema(schema_path)
+
+        door_type = schema.get_type("Door")
+        assert isinstance(door_type, GraphQLObjectType)
+
+        door_type.fields["regularField"] = GraphQLField(GraphQLString)
+
+        naming_config = {"field": {"object": "camelCase"}}
+        convert_field_names(door_type, naming_config, schema)
+
+        assert "instanceTag" in door_type.fields
+        assert "instancetag" not in door_type.fields
+
+        assert "regularField" in door_type.fields
+        assert "RegularField" not in door_type.fields
+
+        assert "isLocked" in door_type.fields  # was "isLocked" -> should stay as is in camelCase
+
+
+class TestConvertEnumValues:
+    """Test enum value conversion functionality - verifies GraphQL schema objects are modified."""
+
+    def test_convert_enum_values_updates_dict_keys_and_objects(self) -> None:
+        """Test that enum conversion updates both dictionary keys and enum value names."""
+        enum_type = GraphQLEnumType(
+            name="TestEnum",
+            values={
+                "OLD_VALUE": GraphQLEnumValue("OLD_VALUE"),
+                "ANOTHER_OLD_VALUE": GraphQLEnumValue("ANOTHER_OLD_VALUE"),
+            },
+        )
+
+        naming_config = {"enumValue": "PascalCase"}
+        convert_enum_values(enum_type, naming_config)
+
+        assert "OldValue" in enum_type.values
+        assert "AnotherOldValue" in enum_type.values
+        assert "OLD_VALUE" not in enum_type.values
+        assert "ANOTHER_OLD_VALUE" not in enum_type.values
+
+    def test_enum_conversion_preserves_other_properties(self) -> None:
+        """Test that other enum value properties are preserved during conversion."""
+        enum_value = GraphQLEnumValue("OLD_VALUE", description="Test description")
+        enum_type = GraphQLEnumType(name="TestEnum", values={"OLD_VALUE": enum_value})
+
+        naming_config = {"enumValue": "camelCase"}
+        convert_enum_values(enum_type, naming_config)
+
+        converted_value = enum_type.values["oldValue"]
+        assert converted_value.description == "Test description"
+
+    def test_no_conversion_when_no_config(self) -> None:
+        """Test that enum values remain unchanged when no config is provided."""
+        enum_type = GraphQLEnumType(name="TestEnum", values={"OLD_VALUE": GraphQLEnumValue("OLD_VALUE")})
+
+        convert_enum_values(enum_type, {})
+
+        assert "OLD_VALUE" in enum_type.values
+
+
+class TestInstanceTagConversion:
+    """Test instance tag expansion with naming conversion."""
+
+    def test_expand_instance_tag_with_naming_config(self) -> None:
+        """Test that instance tag expansion applies naming conversion."""
+        schema_path = Path(__file__).parent / "test_expanded_instances" / "test_schema.graphql"
+        schema = load_schema(schema_path)
+        object_types = get_all_object_types(schema)
+        instance_tag_objects = get_all_objects_with_directive(object_types, "instanceTag")
+
+        assert len(instance_tag_objects) > 0
+        door_position = next((obj for obj in instance_tag_objects if obj.name == "DoorPosition"), None)
+        assert door_position is not None
+
+        naming_config = {"instanceTag": "PascalCase"}
+        result = expand_instance_tag(door_position, naming_config)
+
+        expected = ["Row1.Driverside", "Row1.Passengerside", "Row2.Driverside", "Row2.Passengerside"]
+        assert set(result) == set(expected)
+
+    def test_expand_instance_tag_without_naming_config(self) -> None:
+        """Test that instance tag expansion works without naming config."""
+        schema_path = Path(__file__).parent / "test_expanded_instances" / "test_schema.graphql"
+        schema = load_schema(schema_path)
+        object_types = get_all_object_types(schema)
+        instance_tag_objects = get_all_objects_with_directive(object_types, "instanceTag")
+
+        door_position = next((obj for obj in instance_tag_objects if obj.name == "DoorPosition"), None)
+        assert door_position is not None
+
+        result = expand_instance_tag(door_position)
+
+        expected = ["ROW1.DRIVERSIDE", "ROW1.PASSENGERSIDE", "ROW2.DRIVERSIDE", "ROW2.PASSENGERSIDE"]
+        assert set(result) == set(expected)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -212,6 +212,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d2/1c/2f26665d4be4f1b82b2dfe46f3bd7901582863ddf1bd597309b5d0a5e6d4/bump_my_version-1.2.1.tar.gz", hash = "sha256:96c48f880c149c299312f983d06b50e0277ffc566e64797bf3a6c240bce2dfcc", size = 1137281, upload-time = "2025-07-19T11:52:03.235Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5c/f4/40db87f649d9104c5fe69706cc455e24481b90024b2aacb64cc0ef205536/bump_my_version-1.2.1-py3-none-any.whl", hash = "sha256:ddb41d5f30abdccce9d2dc873e880bdf04ec8c7e7237c73a4c893aa10b7d7587", size = 59567, upload-time = "2025-07-19T11:52:01.343Z" },
+]
+
+[[package]]
+name = "case-converter"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/09/f5b4cf1f5da361e7c6f5f5f5d8bbf313a57d01574194f84abed68447fbb6/case_converter-1.2.0.tar.gz", hash = "sha256:4e0281ae60d4335e57300bafd61cfb3fa65734587fe9efd32f6cec1a506685c5", size = 8760, upload-time = "2025-02-19T16:49:34.891Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/8e/32a7ab1ac97de46e6a0d45b1fcfe1ad7ba9a523a6fb449662ccf39b9591e/case_converter-1.2.0-py3-none-any.whl", hash = "sha256:bb5bc6b1e121c394a6de6526cd3f8be0f5c5817c40d32251cce28a2cf4a72d8c", size = 16250, upload-time = "2025-02-19T16:49:30.48Z" },
 ]
 
 [[package]]
@@ -2165,6 +2174,7 @@ name = "s2dm"
 source = { editable = "." }
 dependencies = [
     { name = "ariadne" },
+    { name = "case-converter" },
     { name = "click" },
     { name = "graphql-core" },
     { name = "langcodes" },
@@ -2195,6 +2205,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "ariadne", specifier = ">=0.24.0" },
+    { name = "case-converter", specifier = ">=1.2.0" },
     { name = "click", specifier = ">=8.1.7" },
     { name = "graphql-core", specifier = ">=3.2.6" },
     { name = "langcodes", specifier = ">=3.5.0" },


### PR DESCRIPTION
This PR replaces https://github.com/COVESA/s2dm/pull/104


feat(export): integrate naming conversion in schema exporters

docs(export): add naming conversion documentation

style: apply formatting fixes

feat(naming): implement naming conversion for instance expansion

feat(naming): implement naming config validation

feat(naming): implement instances name conversion in the vspec exporter

style(vspec): apply formatting fixes

docs(naming): update readme file

docs(naming): update readme file

feat(utils): implement is_built_in_type

fix(naming): mutate schema in-place in apply_naming_to_schema

refactor(naming): document functions and remove unnecessary logic

refactor(naming): combine loops in apply_naming_to_schema

refactor(naming): extract apply_naming_to_instance_values to naming_utils

docs(naming): add documentation to docs-gen