### PR TITLE
exporters/vspec: warn on unmapped units instead of silent drop

### DIFF
--- a/src/s2dm/exporters/vspec.py
+++ b/src/s2dm/exporters/vspec.py
@@ -285,8 +285,15 @@ def process_field(
         # TODO: Map the unit name. i.e., SCREAMMING_SNAKE_CASE used in graphql to abbreviated vss unit name.
         if "unit" in field.args:
             unit_arg = field.args["unit"].default_value
-            if unit_arg is not None and unit_arg is not Undefined and unit_arg in UNITS_DICT:
-                field_dict["unit"] = UNITS_DICT[unit_arg]
+            if unit_arg is not None and unit_arg is not Undefined:
+                if unit_arg in UNITS_DICT:
+                    field_dict["unit"] = UNITS_DICT[unit_arg]
+                else:
+                    log.warning(
+                        f"Unit '{unit_arg}' on field '{concat_field_name}' is not mapped in "
+                        f"UNITS_DICT; the unit will be omitted from the YAML output. Add the "
+                        f"unit to UNITS_DICT in s2dm/exporters/vspec.py to preserve it."
+                    )
 
         if has_given_directive(field, "metadata"):
             metadata_directive = None

--- a/tests/test_vspec.py
+++ b/tests/test_vspec.py
@@ -1,0 +1,89 @@
+"""Unit tests for the vspec exporter."""
+
+import logging
+from collections.abc import Callable
+
+import pytest
+from graphql import GraphQLSchema
+
+from s2dm.exporters.utils.schema_loader import process_schema
+from s2dm.exporters.vspec import translate_to_vspec
+
+# A minimal schema with two scalar fields that take a unit argument:
+#   - `length` defaults to `M` (mapped in UNITS_DICT to "m")
+#   - `unmapped` defaults to `BANANA` (deliberately unknown)
+#
+# `BANANA` is not in `UNITS_DICT`, so the exporter must:
+#   1. omit the unit from the YAML output for that field, and
+#   2. log a `WARNING` so the silent drop is visible to the user.
+SCHEMA_WITH_UNMAPPED_UNIT = """
+enum LengthUnit {
+    M
+    KILOM
+}
+
+enum BananaUnit {
+    BANANA
+}
+
+type Vehicle {
+    length(unit: LengthUnit = M): Float
+    unmapped(unit: BananaUnit = BANANA): Float
+}
+"""
+
+
+def _to_vspec(schema_builder: Callable[[str], GraphQLSchema], schema_str: str) -> str:
+    schema = schema_builder(schema_str)
+    annotated = process_schema(schema, {}, None, None, None, False)
+    return translate_to_vspec(annotated)
+
+
+def test_unmapped_unit_emits_warning_and_is_dropped(
+    schema_builder: Callable[[str], GraphQLSchema],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Unrecognized units must surface a warning rather than vanishing silently."""
+    with caplog.at_level(logging.WARNING, logger="s2dm"):
+        yaml_out = _to_vspec(schema_builder, SCHEMA_WITH_UNMAPPED_UNIT)
+
+    # The mapped unit is present in the YAML; the unmapped one is dropped.
+    assert "unit: m\n" in yaml_out
+    assert "BANANA" not in yaml_out
+
+    # And the user is told why the unmapped one disappeared.
+    warning_messages = [
+        record.getMessage() for record in caplog.records if record.levelno == logging.WARNING
+    ]
+    matching = [msg for msg in warning_messages if "BANANA" in msg and "Vehicle.unmapped" in msg]
+    assert matching, (
+        f"Expected a WARNING about the unmapped 'BANANA' unit on Vehicle.unmapped, "
+        f"got: {warning_messages}"
+    )
+
+
+def test_mapped_unit_does_not_warn(
+    schema_builder: Callable[[str], GraphQLSchema],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Recognized units must round-trip cleanly without spurious warnings."""
+    schema_str = """
+    enum LengthUnit {
+        M
+        KILOM
+    }
+
+    type Vehicle {
+        length(unit: LengthUnit = M): Float
+    }
+    """
+    with caplog.at_level(logging.WARNING, logger="s2dm"):
+        yaml_out = _to_vspec(schema_builder, schema_str)
+
+    assert "unit: m\n" in yaml_out
+    unit_warnings = [
+        record.getMessage()
+        for record in caplog.records
+        if record.levelno == logging.WARNING and "UNITS_DICT" in record.getMessage()
+    ]
+    assert not unit_warnings, f"Did not expect any UNITS_DICT warnings, got: {unit_warnings}"


### PR DESCRIPTION
Small fix to a quiet data-loss path in the vspec exporter.

If a user writes `unit: SomeUnit = SOME_VALUE` in their GraphQL schema and `SOME_VALUE` isn't present in `UNITS_DICT` (the hardcoded SCREAMING_SNAKE_CASE → abbreviated VSS name map at the top of `vspec.py`), the unit was previously dropped from the YAML output with no warning — the user's intent silently vanished, and they'd have to diff the output to notice.

This PR adds a `log.warning` when an unmapped unit is encountered, naming both the field and the unit value, so the user can either:

- add the unit to `UNITS_DICT`, or
- adjust their schema to use a unit that's already mapped.

No behaviour change for fields with mapped units.

The existing `TODO` at this site about using vss-tools `dynamic_units` directly is intentionally left in place — that's a bigger refactor and deserves its own PR.

### Tests

Adds `tests/test_vspec.py` covering:
- a schema with one mapped unit (`M` → `"m"`) and one unmapped unit (`BANANA`) → asserts the mapped one round-trips, the unmapped one is dropped, **and** the warning fires with both the field path and unit value
- a schema with only mapped units → asserts no UNITS_DICT warnings fire

Local verification: 534 passed (the deselected tests need the `graphql-inspector` Node CLI; CI has it).