### PR TITLE
chore: open files with encoding=utf-8

### DIFF
--- a/src/s2dm/exporters/spec_history.py
+++ b/src/s2dm/exporters/spec_history.py
@@ -244,6 +244,6 @@ class SpecHistoryExporter:
         filename = SpecHistoryExporter.generate_history_filename(id_value)
         file_path: Path = history_dir / filename
 
-        with open(file_path, "w") as f:
+        with open(file_path, "w", encoding="utf-8") as f:
             f.write(type_def)
         log.debug(f"Saved type definition for {parent_type} to {file_path}")

--- a/src/s2dm/registry/spec_history.py
+++ b/src/s2dm/registry/spec_history.py
@@ -68,7 +68,7 @@ class SpecHistoryModel(ConceptBaseModel[SpecHistoryNode]):
 
 def load_json_file(file_path: Path) -> dict[str, Any]:
     """Load a JSON file and return its contents."""
-    with open(file_path) as f:
+    with open(file_path, encoding="utf-8") as f:
         data = json.load(f)
     if not isinstance(data, dict):
         raise ValueError(f"Expected JSON object in {file_path}, got {type(data).__name__}")
@@ -77,7 +77,7 @@ def load_json_file(file_path: Path) -> dict[str, Any]:
 
 def save_spec_history(spec_history: SpecHistoryModel, file_path: Path) -> None:
     """Save a spec history model to a JSON-LD file."""
-    with open(file_path, "w") as f:
+    with open(file_path, "w", encoding="utf-8") as f:
         json.dump(spec_history.to_json_ld(), f, indent=2)
 
 


### PR DESCRIPTION
Three `open()` calls in the spec_history modules read or wrote files without specifying `encoding="utf-8"`, falling back to Python's locale-dependent default. On Windows or systems whose default locale isn't UTF-8, GraphQL type definitions and JSON-LD spec history files containing non-ASCII characters in descriptions or comments would be silently corrupted (write side) or fail to parse (read side).

Sites fixed:
- `src/s2dm/exporters/spec_history.py:247` — type-definition write
- `src/s2dm/registry/spec_history.py:71` — JSON load
- `src/s2dm/registry/spec_history.py:80` — JSON-LD save

The other `open()` calls in the codebase (`vspec.py`, `cli.py`, `concept_uri.py`, `naming_config.py`, `variant_ids.py`) already pass `encoding="utf-8"` correctly. This brings the spec_history modules in line.

No behaviour change on macOS/Linux where the default locale is already UTF-8. Local verification: 532 tests pass.