### PR TITLE
feat: improve instance tag

### DIFF
--- a/docs-gen/config/_default/hugo.toml
+++ b/docs-gen/config/_default/hugo.toml
@@ -45,7 +45,7 @@ copyRight = "Copyright (c) 2020-2024 Thulite"
   priority = 0.5
 
 [caches]
-  [caches.getjson]
+  [caches.getresource]
     dir = ":cacheDir/:project"
     maxAge = -1 # "30m"
 

--- a/docs-gen/content/docs/tools/cli.md
+++ b/docs-gen/content/docs/tools/cli.md
@@ -236,7 +236,10 @@ s2dm check constraints -s <schema_path>
 
 The command performs the following validations:
 
-1. **instanceTag Field and Object Rules**: Validates proper usage of `@instanceTag` directive and `instanceTag` fields
+1. **@instanceTag Rules**: Validates correct usage of the `@instanceTag` directive:
+   - A field marked with `@instanceTag` must reference an object type that is itself marked with `@instanceTag`
+   - An object may have at most one `@instanceTag` field
+   - Every field of an `@instanceTag` object must be an enum
 2. **@range Directive**: Ensures `min` value is less than or equal to `max` value
 3. **@cardinality Directive**: Ensures `min` value is less than or equal to `max` value
 4. **Naming Conventions** (optional): When `--naming-config` is provided, validates that type names, field names, enum values, and other elements follow the specified naming conventions
@@ -263,7 +266,7 @@ See [Naming Configuration](#naming-configuration) for details on the naming conf
 
 ## Compose Command
 
-The `compose` command merges multiple GraphQL schema files into a single unified schema file. It automatically adds `@reference` directives to track which file each type was obtained from.
+The `compose` command merges multiple GraphQL schema files into a single unified schema file. If `@reference` is defined in the schema, it automatically adds `@reference` directives to track which file each type was obtained from.
 
 ### Basic Usage
 
@@ -300,7 +303,7 @@ s2dm compose -s ./schemas/vehicle -s ./schemas/person -o composed.graphql
 
 ### Reference Directives
 
-The compose command automatically adds `@reference(source: String!)` directives to all types to track their source:
+If `@reference(source: String!)` is defined in the schema, the compose command automatically adds `@reference(source: String!)` directives to all types to track their source:
 
 ```graphql
 type Vehicle @reference(source: "schema1.graphql") {
@@ -379,7 +382,7 @@ This exporter translates the given GraphQL schema to [JSON Schema](https://json-
 Consider the following GraphQL schema:
 
 ```gql
-directive @instanceTag on OBJECT
+directive @instanceTag on OBJECT | FIELD_DEFINITION
 directive @metadata(comment: String, vssType: String) on FIELD_DEFINITION | OBJECT
 
 type Vehicle @metadata(comment: "Vehicle entity", vssType: "branch") {
@@ -389,7 +392,7 @@ type Vehicle @metadata(comment: "Vehicle entity", vssType: "branch") {
 
 type Door {
     locked: Boolean!
-    instanceTag: InCabinArea2x3
+    inCabinArea: InCabinArea2x3 @instanceTag
 }
 
 enum TwoRowsInCabinEnum {
@@ -421,8 +424,41 @@ The JSON Schema exporter with `--expanded-instances` produces:
         "id": {
           "type": "string"
         },
-        "Door": {
-          "$ref": "#/$defs/Door_Row"
+        "door": {
+          "additionalProperties": false,
+          "properties": {
+            "ROW1": {
+              "additionalProperties": false,
+              "properties": {
+                "DRIVERSIDE": {
+                  "$ref": "#/$defs/Door"
+                },
+                "MIDDLE": {
+                  "$ref": "#/$defs/Door"
+                },
+                "PASSENGERSIDE": {
+                  "$ref": "#/$defs/Door"
+                }
+              },
+              "type": "object"
+            },
+            "ROW2": {
+              "additionalProperties": false,
+              "properties": {
+                "DRIVERSIDE": {
+                  "$ref": "#/$defs/Door"
+                },
+                "MIDDLE": {
+                  "$ref": "#/$defs/Door"
+                },
+                "PASSENGERSIDE": {
+                  "$ref": "#/$defs/Door"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
         }
       },
       "type": "object",
@@ -431,8 +467,7 @@ The JSON Schema exporter with `--expanded-instances` produces:
         "vssType": "branch"
       },
       "required": [
-        "id",
-        "Door"
+        "id"
       ]
     },
     "Door": {
@@ -446,37 +481,11 @@ The JSON Schema exporter with `--expanded-instances` produces:
       "required": [
         "locked"
       ]
-    },
-    "Door_Row": {
-      "additionalProperties": false,
-      "properties": {
-        "ROW1": {
-          "$ref": "#/$defs/Door_Column"
-        },
-        "ROW2": {
-          "$ref": "#/$defs/Door_Column"
-        }
-      },
-      "type": "object"
-    },
-    "Door_Column": {
-      "additionalProperties": false,
-      "properties": {
-        "DRIVERSIDE": {
-          "$ref": "#/$defs/Door"
-        },
-        "MIDDLE": {
-          "$ref": "#/$defs/Door"
-        },
-        "PASSENGERSIDE": {
-          "$ref": "#/$defs/Door"
-        }
-      },
-      "type": "object"
     }
   },
-  "title": "Vehicle",
-  "$ref": "#/$defs/Vehicle"
+  "type": "object",
+  "title": "GraphQL Schema",
+  "description": "JSON Schema generated from GraphQL schema"
 }
 ```
 
@@ -527,13 +536,16 @@ Given this GraphQL schema:
 
 ```graphql
 type Vehicle {
-  id: ID!                    # Non-null
-  description: String        # Nullable
-  year: Int                  # Nullable
-  category: VehicleCategory  # Nullable enum
-  parts: [Part]              # Nullable list of nullable parts
-  doors: [Door!]!            # Non-null list of non-null doors
-  wheels: [Wheel]!           # Non-null list of nullable wheels
+  id: ID!                       # Non-null
+  description: String           # Nullable
+  category: VehicleCategory     # Nullable enum
+  doorsOptional: [Door]         # Nullable list of nullable doors
+  doorsRequired: [Door]!        # Non-null list of nullable doors
+  doors: [Door!]!               # Non-null list of non-null doors
+}
+
+type Door {
+  id: ID!
 }
 
 enum VehicleCategory {
@@ -606,8 +618,9 @@ enum VehicleCategory {
       ]
     }
   },
-  "title": "Vehicle",
-  "$ref": "#/$defs/Vehicle"
+  "type": "object",
+  "title": "GraphQL Schema",
+  "description": "JSON Schema generated from GraphQL schema"
 }
 ```
 
@@ -706,8 +719,9 @@ enum VehicleCategory {
       ]
     }
   },
-  "title": "Vehicle",
-  "$ref": "#/$defs/Vehicle"
+  "type": "object",
+  "title": "GraphQL Schema",
+  "description": "JSON Schema generated from GraphQL schema"
 }
 ```
 
@@ -807,6 +821,7 @@ classes:
   Vehicle:
     attributes:
       id:
+        identifier: true
         range: string
         required: true
       make:
@@ -816,6 +831,7 @@ classes:
         range: integer
       fuelType:
         range: FuelType
+    tree_root: true
 ```
 
 #### Type Mappings
@@ -894,7 +910,7 @@ type Cabin {
 
 type Door {
   isLocked: Boolean
-  instanceTag: DoorPosition
+  doorPosition: DoorPosition @instanceTag
 }
 
 type DoorPosition @instanceTag {
@@ -924,7 +940,7 @@ query Selection {
   cabin {
     doors {
       isLocked
-      instanceTag {
+      doorPosition {
         row
         side
       }
@@ -942,14 +958,13 @@ The Protobuf exporter produces:
 syntax = "proto3";
 
 import "google/protobuf/descriptor.proto";
-import "buf/validate/validate.proto";
 
 extend google.protobuf.MessageOptions {
-  string source = 50001;
+  string message_source = 50001;
 }
 
 message RowEnum {
-  option (source) = "RowEnum";
+  option (message_source) = "RowEnum";
 
   enum Enum {
     ROWENUM_UNSPECIFIED = 0;
@@ -957,9 +972,8 @@ message RowEnum {
     ROW2 = 2;
   }
 }
-
 message SideEnum {
-  option (source) = "SideEnum";
+  option (message_source) = "SideEnum";
 
   enum Enum {
     SIDEENUM_UNSPECIFIED = 0;
@@ -968,29 +982,29 @@ message SideEnum {
   }
 }
 
-message DoorPosition {
-  option (source) = "DoorPosition";
-
-  RowEnum.Enum row = 1;
-  SideEnum.Enum side = 2;
-}
-
 message Cabin {
-  option (source) = "Cabin";
+  option (message_source) = "Cabin";
 
   repeated Door doors = 1;
-  float temperature = 2;
+  optional float temperature = 2;
 }
 
 message Door {
-  option (source) = "Door";
+  option (message_source) = "Door";
 
-  bool isLocked = 1;
-  DoorPosition instanceTag = 2;
+  optional bool isLocked = 1;
+  optional DoorPosition doorPosition = 2;
+}
+
+message DoorPosition {
+  option (message_source) = "DoorPosition";
+
+  optional RowEnum.Enum row = 1;
+  optional SideEnum.Enum side = 2;
 }
 
 message Selection {
-  option (source) = "Query";
+  option (message_source) = "query: Selection";
 
   optional Cabin cabin = 1;
 }
@@ -1073,11 +1087,17 @@ import "google/protobuf/descriptor.proto";
 import "buf/validate/validate.proto";
 
 extend google.protobuf.MessageOptions {
-  string source = 50001;
+  string message_source = 50001;
+}
+
+extend google.protobuf.FieldOptions {
+  string field_source = 50002;
 }
 
 message Selection {
-  bool Vehicle_adas_abs_isEngaged = 1;
+  option (message_source) = "query: Selection";
+
+  optional bool Vehicle_adas_abs_isEngaged = 1 [(field_source) = "ABS"];
 }
 
 ```
@@ -1105,7 +1125,7 @@ type Cabin {
 
 type Door {
   isLocked: Boolean
-  instanceTag: DoorPosition
+  doorPosition: DoorPosition @instanceTag
 }
 
 type DoorPosition @instanceTag {
@@ -1135,7 +1155,7 @@ query Selection {
   cabin {
     doors {
       isLocked
-      instanceTag {
+      doorPosition {
         row
         side
       }
@@ -1144,20 +1164,19 @@ query Selection {
 }
 ```
 
-Default output uses repeated fields and includes the instanceTag field:
+Default output uses repeated fields and includes the doorPosition field:
 
 ```protobuf
 syntax = "proto3";
 
 import "google/protobuf/descriptor.proto";
-import "buf/validate/validate.proto";
 
 extend google.protobuf.MessageOptions {
-  string source = 50001;
+  string message_source = 50001;
 }
 
 message RowEnum {
-  option (source) = "RowEnum";
+  option (message_source) = "RowEnum";
 
   enum Enum {
     ROWENUM_UNSPECIFIED = 0;
@@ -1165,9 +1184,8 @@ message RowEnum {
     ROW2 = 2;
   }
 }
-
 message SideEnum {
-  option (source) = "SideEnum";
+  option (message_source) = "SideEnum";
 
   enum Enum {
     SIDEENUM_UNSPECIFIED = 0;
@@ -1176,30 +1194,28 @@ message SideEnum {
   }
 }
 
-message Door {
-  option (source) = "Door";
-
-  optional bool isLocked = 1;
-  optional DoorPosition instanceTag = 2;
-}
-
-
 message Cabin {
-  option (source) = "Cabin";
+  option (message_source) = "Cabin";
 
   repeated Door doors = 1;
 }
 
+message Door {
+  option (message_source) = "Door";
+
+  optional bool isLocked = 1;
+  optional DoorPosition doorPosition = 2;
+}
 
 message DoorPosition {
-  option (source) = "DoorPosition";
+  option (message_source) = "DoorPosition";
 
   optional RowEnum.Enum row = 1;
   optional SideEnum.Enum side = 2;
 }
 
 message Selection {
-  option (source) = "Query";
+  option (message_source) = "query: Selection";
 
   optional Cabin cabin = 1;
 }
@@ -1216,11 +1232,11 @@ import "google/protobuf/descriptor.proto";
 import "buf/validate/validate.proto";
 
 extend google.protobuf.MessageOptions {
-  string source = 50001;
+  string message_source = 50001;
 }
 
 message RowEnum {
-  option (source) = "RowEnum";
+  option (message_source) = "RowEnum";
 
   enum Enum {
     ROWENUM_UNSPECIFIED = 0;
@@ -1230,7 +1246,7 @@ message RowEnum {
 }
 
 message SideEnum {
-  option (source) = "SideEnum";
+  option (message_source) = "SideEnum";
 
   enum Enum {
     SIDEENUM_UNSPECIFIED = 0;
@@ -1239,36 +1255,36 @@ message SideEnum {
   }
 }
 
-message Door {
-  option (source) = "Door";
-
-  optional bool isLocked = 1;
-}
-
 message Cabin {
-  option (source) = "Cabin";
+  option (message_source) = "Cabin";
 
   Door_Row Door = 1 [(buf.validate.field).required = true];
 }
 
+message Door {
+  option (message_source) = "Door";
+
+  optional bool isLocked = 1;
+}
+
+message Selection {
+  option (message_source) = "query: Selection";
+
+  optional Cabin cabin = 1;
+}
+
 message Door_Side {
-  option (source) = "Door_Side";
+  option (message_source) = "Door_Side";
 
   optional Door DRIVERSIDE = 1;
   optional Door PASSENGERSIDE = 2;
 }
 
 message Door_Row {
-  option (source) = "Door_Row";
+  option (message_source) = "Door_Row";
 
   Door_Side ROW1 = 1 [(buf.validate.field).required = true];
   Door_Side ROW2 = 2 [(buf.validate.field).required = true];
-}
-
-message Selection {
-  option (source) = "Query";
-
-  optional Cabin cabin = 1;
 }
 ```
 
@@ -1276,7 +1292,7 @@ message Selection {
 
 - Instance tag enums (`RowEnum`, `SideEnum`) remain in the output
 - Types with `@instanceTag` directive (`DoorPosition`) are excluded from the output
-- The `instanceTag` field is excluded from the Door message
+- The `doorPosition` field is excluded from the Door message
 - Intermediate types (`Door_Row`, `Door_Side`) are created as top-level messages
 - Field names use the type name (`Door` not `doors`)
 - The field becomes required and non-repeated
@@ -1322,18 +1338,18 @@ import "google/protobuf/descriptor.proto";
 import "buf/validate/validate.proto";
 
 extend google.protobuf.MessageOptions {
-  string source = 50001;
+  string message_source = 50001;
 }
 
 message Vehicle {
-  option (source) = "Vehicle";
+  option (message_source) = "Vehicle";
 
-  int32 speed = 1 [(buf.validate.field).int32 = {gte: 0, lte: 300}];
+  optional int32 speed = 1 [(buf.validate.field).int32 = {gte: 0, lte: 300}];
   repeated string tags = 2 [(buf.validate.field).repeated = {unique: true, min_items: 1, max_items: 10}];
 }
 
 message Selection {
-  option (source) = "Query";
+  option (message_source) = "query: Selection";
 
   optional Vehicle vehicle = 1;
 }
@@ -1390,7 +1406,7 @@ Produces:
 
 ```protobuf
 message User {
-  option (source) = "User";
+  option (message_source) = "User";
 
   string id = 1 [(buf.validate.field).required = true];
   optional string name = 2;
@@ -1626,7 +1642,7 @@ protocol Vehicle {
   record Vehicle {
     string? id;
     string? make;
-    string? status;
+    string? status; /* enum Status */
   }
 }
 ```
@@ -2390,7 +2406,6 @@ The naming configuration system enforces several validation rules to ensure cons
 **Context-specific Rules:**
 
 - **EnumValue-InstanceTag pairing**: If `enumValue` is present in the configuration for transformation commands, `instanceTag` must also be present.
-- **InstanceTag preservation**: The literal field name `instanceTag` is never transformed or validated, regardless of naming configuration, to preserve its semantic meaning.
 
 #### Notes
 
@@ -2418,13 +2433,15 @@ s2dm compose --expanded-instances ...
 Given a schema with instance tags:
 
 ```graphql
+directive @instanceTag on OBJECT | FIELD_DEFINITION
+
 type Cabin {
   doors: [Door]
 }
 
 type Door {
   isLocked: Boolean
-  instanceTag: DoorPosition
+  doorPosition: DoorPosition @instanceTag
 }
 
 type DoorPosition @instanceTag {
@@ -2445,7 +2462,7 @@ enum SideEnum {
 
 **Without `--expanded-instances` (default):**
 
-The schema structure remains as-is with list fields and instanceTag preserved.
+The schema structure remains as-is with list fields and the doorPosition field preserved.
 
 **With `--expanded-instances`:**
 
@@ -2453,12 +2470,12 @@ The schema is transformed to use nested intermediate types:
 
 ```graphql
 type Cabin {
-  Door: Door_Row
+  Door: Door_Row!
 }
 
 type Door_Row {
-  ROW1: Door_Side
-  ROW2: Door_Side
+  ROW1: Door_Side!
+  ROW2: Door_Side!
 }
 
 type Door_Side {
@@ -2486,6 +2503,6 @@ enum SideEnum {
 - **Field names**: Plural list fields (`doors`) are renamed to singular (`Door`)
 - **Field types**: List types (`[Door]`) become intermediate types (`Door_Row`)
 - **Intermediate types**: New types are created representing the cartesian product of instance tag enums (`Door_Row`, `Door_Side`)
-- **Instance tag removal**: The `instanceTag` field is removed from the base type (`Door`)
+- **Instance tag removal**: The `doorPosition` field is removed from the base type (`Door`)
 - **Type removal**: Types with `@instanceTag` directive (`DoorPosition`) are removed from the schema
 - **Enum preservation**: Instance tag enums (`RowEnum`, `SideEnum`) remain in the schema

--- a/docs-gen/content/docs/tools/cli.md
+++ b/docs-gen/content/docs/tools/cli.md
@@ -2433,10 +2433,11 @@ s2dm compose --expanded-instances ...
 Given a schema with instance tags:
 
 ```graphql
-directive @instanceTag on OBJECT | FIELD_DEFINITION
+directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM
 
 type Cabin {
   doors: [Door]
+  mirrors: [Mirror]
 }
 
 type Door {
@@ -2449,6 +2450,17 @@ type DoorPosition @instanceTag {
   side: SideEnum
 }
 
+type Mirror {
+  isFolded: Boolean
+  position: MirrorPosition @instanceTag
+}
+
+enum MirrorPosition @instanceTag {
+  LEFT
+  CENTER
+  RIGHT
+}
+
 enum RowEnum {
   ROW1
   ROW2
@@ -2460,22 +2472,44 @@ enum SideEnum {
 }
 ```
 
+An instance tag can be backed either by an object type (`DoorPosition`, whose enum fields form a multi-dimensional cartesian product) or directly by an enum (`MirrorPosition`, a single dimension marked with `@instanceTag` on the enum itself).
+
 **Without `--expanded-instances` (default):**
 
-The schema structure remains as-is with list fields and the doorPosition field preserved.
+The schema structure remains as-is with the list fields and the instance-tag fields (`doorPosition`, `position`) preserved.
 
 **With `--expanded-instances`:**
 
 The schema is transformed to use nested intermediate types:
 
 ```graphql
+directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM
+
 type Cabin {
   Door: Door_Row!
+  Mirror: Mirror_Position!
 }
 
-type Door_Row {
-  ROW1: Door_Side!
-  ROW2: Door_Side!
+type Door {
+  isLocked: Boolean
+}
+
+type Mirror {
+  isFolded: Boolean
+}
+
+enum RowEnum {
+  ROW1
+  ROW2
+}
+
+enum SideEnum {
+  DRIVERSIDE
+  PASSENGERSIDE
+}
+
+type Query {
+  cabin: Cabin
 }
 
 type Door_Side {
@@ -2483,8 +2517,48 @@ type Door_Side {
   PASSENGERSIDE: Door
 }
 
-type Door {
-  isLocked: Boolean
+type Door_Row {
+  ROW1: Door_Side!
+  ROW2: Door_Side!
+}
+
+type Mirror_Position {
+  LEFT: Mirror
+  CENTER: Mirror
+  RIGHT: Mirror
+}
+```
+
+#### Key Changes
+
+- **Field names**: Plural list fields (`doors`, `mirrors`) are renamed to singular (`Door`, `Mirror`)
+- **Field types**: List types (`[Door]`) become intermediate types (`Door_Row`)
+- **Intermediate types**: New types are created representing the cartesian product of instance tag enums (`Door_Row`, `Door_Side`); an enum-backed tag is a single dimension, so it produces one intermediate type (`Mirror_Position`)
+- **Instance tag removal**: The instance-tag fields (`doorPosition`, `position`) are removed from the base types (`Door`, `Mirror`)
+- **Type removal**: Object types with the `@instanceTag` directive (`DoorPosition`) and enums marked with `@instanceTag` (`MirrorPosition`) are removed from the schema
+- **Enum preservation**: Enums used as fields inside an `@instanceTag` object (`RowEnum`, `SideEnum`) remain in the schema
+
+#### Excluding Instance Combinations
+
+The `@instanceTag` directive accepts an optional `exclude` argument — a list of instance combinations that should be pruned from the expansion. Each entry is the dot-joined path of enum values for a single combination (for example `"ROW1.MIDDLE"`), in the same order as the fields of the `@instanceTag` type.
+
+Use it when a particular combination does not exist in the modeled entity (for example, a vehicle whose front row has no middle seat):
+
+```graphql
+directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM
+
+type Cabin {
+  seats: [Seat]
+}
+
+type Seat {
+  isOccupied: Boolean
+  seatPosition: SeatPosition @instanceTag(exclude: ["ROW1.MIDDLE"])
+}
+
+type SeatPosition @instanceTag {
+  row: RowEnum
+  position: PositionEnum
 }
 
 enum RowEnum {
@@ -2492,17 +2566,66 @@ enum RowEnum {
   ROW2
 }
 
-enum SideEnum {
-  DRIVERSIDE
-  PASSENGERSIDE
+enum PositionEnum {
+  LEFT
+  MIDDLE
+  RIGHT
+}
+
+type Query {
+  cabin: Cabin
 }
 ```
 
-#### Key Changes
+Running the expansion:
 
-- **Field names**: Plural list fields (`doors`) are renamed to singular (`Door`)
-- **Field types**: List types (`[Door]`) become intermediate types (`Door_Row`)
-- **Intermediate types**: New types are created representing the cartesian product of instance tag enums (`Door_Row`, `Door_Side`)
-- **Instance tag removal**: The `doorPosition` field is removed from the base type (`Door`)
-- **Type removal**: Types with `@instanceTag` directive (`DoorPosition`) are removed from the schema
-- **Enum preservation**: Instance tag enums (`RowEnum`, `SideEnum`) remain in the schema
+```bash
+s2dm compose -s schema.graphql --expanded-instances -o expanded.graphql
+```
+
+produces the following schema. The excluded `ROW1.MIDDLE` combination is dropped, so the two rows no longer share a single position type — `ROW1` only expands to `LEFT` and `RIGHT`, while `ROW2` retains all three positions:
+
+```graphql
+directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM
+
+type Cabin {
+  Seat: Seat_Row!
+}
+
+type Seat {
+  isOccupied: Boolean
+}
+
+enum RowEnum {
+  ROW1
+  ROW2
+}
+
+enum PositionEnum {
+  LEFT
+  MIDDLE
+  RIGHT
+}
+
+type Query {
+  cabin: Cabin
+}
+
+type Seat_ROW1_Position {
+  LEFT: Seat
+  RIGHT: Seat
+}
+
+type Seat_ROW2_Position {
+  LEFT: Seat
+  MIDDLE: Seat
+  RIGHT: Seat
+}
+
+type Seat_Row {
+  ROW1: Seat_ROW1_Position!
+  ROW2: Seat_ROW2_Position!
+}
+```
+
+If an `exclude` entry matches no instance combination, the expansion fails with an error rather than silently ignoring it.

--- a/docs-gen/static/examples/seat-capabilities/full_schema.graphql
+++ b/docs-gen/static/examples/seat-capabilities/full_schema.graphql
@@ -6,7 +6,7 @@ directive @cardinality(min: Int, max: Int) on FIELD_DEFINITION
 
 directive @noDuplicates on FIELD_DEFINITION
 
-directive @instanceTag on OBJECT | FIELD_DEFINITION
+directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM
 
 directive @metadata(comment: String, vssType: String) on FIELD_DEFINITION | OBJECT
 

--- a/docs-gen/static/examples/seat-capabilities/full_schema.graphql
+++ b/docs-gen/static/examples/seat-capabilities/full_schema.graphql
@@ -6,7 +6,7 @@ directive @cardinality(min: Int, max: Int) on FIELD_DEFINITION
 
 directive @noDuplicates on FIELD_DEFINITION
 
-directive @instanceTag on OBJECT
+directive @instanceTag on OBJECT | FIELD_DEFINITION
 
 directive @metadata(comment: String, vssType: String) on FIELD_DEFINITION | OBJECT
 
@@ -86,7 +86,7 @@ degrees = seat tilted backwards, seat x-axis tilted upward, seat z-axis is tilte
   backrest: Backrest
   headrest: Headrest
   seating: Seating
-  instanceTag: InCabinArea2x2
+  inCabinArea: InCabinArea2x2 @instanceTag
 }
 
 type Airbag {

--- a/docs-gen/static/examples/seat-domain-model/full_schema.graphql
+++ b/docs-gen/static/examples/seat-domain-model/full_schema.graphql
@@ -4,7 +4,7 @@ directive @range(min: Float, max: Float) on FIELD_DEFINITION
 
                     directive @noDuplicates on FIELD_DEFINITION
 
-                    directive @instanceTag on OBJECT
+                    directive @instanceTag on OBJECT | FIELD_DEFINITION
 
                     directive @metadata(comment: String, vssType: String) on FIELD_DEFINITION | OBJECT
 
@@ -184,7 +184,7 @@ directive @range(min: Float, max: Float) on FIELD_DEFINITION
                       backrest: Backrest
                       headrest: Headrest
                       seating: Seating
-                      instanceTag: InCabinArea2x2
+                      inCabinArea: InCabinArea2x2 @instanceTag
                     }
 
                     """Airbag signals."""

--- a/docs-gen/static/examples/seat-domain-model/full_schema.graphql
+++ b/docs-gen/static/examples/seat-domain-model/full_schema.graphql
@@ -4,7 +4,7 @@ directive @range(min: Float, max: Float) on FIELD_DEFINITION
 
                     directive @noDuplicates on FIELD_DEFINITION
 
-                    directive @instanceTag on OBJECT | FIELD_DEFINITION
+                    directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM
 
                     directive @metadata(comment: String, vssType: String) on FIELD_DEFINITION | OBJECT
 

--- a/docs-gen/static/examples/seat-to-vspec/full_sdl.graphql
+++ b/docs-gen/static/examples/seat-to-vspec/full_sdl.graphql
@@ -4,7 +4,7 @@ directive @range(min: Float, max: Float) on FIELD_DEFINITION
 
                     directive @noDuplicates on FIELD_DEFINITION
 
-                    directive @instanceTag on OBJECT
+                    directive @instanceTag on OBJECT | FIELD_DEFINITION
 
                     directive @metadata(comment: String, vssType: String) on FIELD_DEFINITION | OBJECT
 
@@ -184,7 +184,7 @@ directive @range(min: Float, max: Float) on FIELD_DEFINITION
                       backrest: Backrest
                       headrest: Headrest
                       seating: Seating
-                      instanceTag: InCabinArea2x2
+                      inCabinArea: InCabinArea2x2 @instanceTag
                     }
 
                     """Airbag signals."""

--- a/docs-gen/static/examples/seat-to-vspec/full_sdl.graphql
+++ b/docs-gen/static/examples/seat-to-vspec/full_sdl.graphql
@@ -4,7 +4,7 @@ directive @range(min: Float, max: Float) on FIELD_DEFINITION
 
                     directive @noDuplicates on FIELD_DEFINITION
 
-                    directive @instanceTag on OBJECT | FIELD_DEFINITION
+                    directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM
 
                     directive @metadata(comment: String, vssType: String) on FIELD_DEFINITION | OBJECT
 

--- a/docs-gen/static/examples/trailer/full_schema.graphql
+++ b/docs-gen/static/examples/trailer/full_schema.graphql
@@ -4,7 +4,7 @@ directive @cardinality(min: Int, max: Int) on FIELD_DEFINITION
 
 directive @noDuplicates on FIELD_DEFINITION
 
-directive @instanceTag on OBJECT
+directive @instanceTag on OBJECT | FIELD_DEFINITION
 
 directive @metadata(comment: String, vssType: String) on FIELD_DEFINITION | OBJECT
 
@@ -112,7 +112,7 @@ type VehicleTrailer {
 
     """Number of axles on the trailer"""
     axleCount: UInt8
-    instanceTag: TrailerTag
+    trailer: TrailerTag @instanceTag
 }
 
 enum VehicleTrailerKindEnum {
@@ -185,7 +185,7 @@ from the midway points between the inner and outer tires.
 
     """Number of wheels on the axle"""
     wheelCount: UInt8
-    instanceTag: TrailerAxleTag
+    trailerAxle: TrailerAxleTag @instanceTag
 }
 
 """
@@ -199,7 +199,7 @@ type VehicleTrailerWheel {
     speed(unit: Velocity_Unit_Enum = KILOMETER_PER_HOUR): Float
     brake: TrailerWheelBrake
     tire: TrailerWheelTire
-    instanceTag: TrailerWheelTag
+    trailerWheel: TrailerWheelTag @instanceTag
 }
 
 """Brake signals for wheel"""

--- a/docs-gen/static/examples/trailer/full_schema.graphql
+++ b/docs-gen/static/examples/trailer/full_schema.graphql
@@ -4,7 +4,7 @@ directive @cardinality(min: Int, max: Int) on FIELD_DEFINITION
 
 directive @noDuplicates on FIELD_DEFINITION
 
-directive @instanceTag on OBJECT | FIELD_DEFINITION
+directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM
 
 directive @metadata(comment: String, vssType: String) on FIELD_DEFINITION | OBJECT
 

--- a/examples/schema-rdf/sample.graphql
+++ b/examples/schema-rdf/sample.graphql
@@ -19,7 +19,7 @@ enum CabinKindEnum {
 
 """Door with instance tag, isOpen, and window."""
 type Door {
-  instanceTag: InCabinArea2x2
+  inCabinArea: InCabinArea2x2 @instanceTag
   isOpen: Boolean
   window: Window
 }

--- a/examples/seat-to-vspec/modular_seat_spec/CustomExtensions/ExtendedSeat.graphql
+++ b/examples/seat-to-vspec/modular_seat_spec/CustomExtensions/ExtendedSeat.graphql
@@ -1,5 +1,5 @@
 extend type Seat {
-    instanceTag: InCabinArea2x2
+    inCabinArea: InCabinArea2x2 @instanceTag
 }
 
 # Example if a vehicle would have 10 rows

--- a/examples/trailer/full_schema.graphl
+++ b/examples/trailer/full_schema.graphl
@@ -4,7 +4,7 @@ directive @cardinality(min: Int, max: Int) on FIELD_DEFINITION
 
 directive @noDuplicates on FIELD_DEFINITION
 
-directive @instanceTag on OBJECT
+directive @instanceTag on OBJECT | FIELD_DEFINITION
 
 directive @metadata(comment: String, vssType: String) on FIELD_DEFINITION | OBJECT
 
@@ -112,7 +112,7 @@ type VehicleTrailer {
 
     """Number of axles on the trailer"""
     axleCount: UInt8
-    instanceTag: TrailerTag
+    trailer: TrailerTag @instanceTag
 }
 
 enum VehicleTrailerKindEnum {
@@ -185,7 +185,7 @@ from the midway points between the inner and outer tires.
 
     """Number of wheels on the axle"""
     wheelCount: UInt8
-    instanceTag: TrailerAxleTag
+    trailerAxle: TrailerAxleTag @instanceTag
 }
 
 """
@@ -199,7 +199,7 @@ type VehicleTrailerWheel {
     speed(unit: Velocity_Unit_Enum = KILOMETER_PER_HOUR): Float
     brake: TrailerWheelBrake
     tire: TrailerWheelTire
-    instanceTag: TrailerWheelTag
+    trailerWheel: TrailerWheelTag @instanceTag
 }
 
 """Brake signals for wheel"""

--- a/examples/trailer/full_schema.graphl
+++ b/examples/trailer/full_schema.graphl
@@ -4,7 +4,7 @@ directive @cardinality(min: Int, max: Int) on FIELD_DEFINITION
 
 directive @noDuplicates on FIELD_DEFINITION
 
-directive @instanceTag on OBJECT | FIELD_DEFINITION
+directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM
 
 directive @metadata(comment: String, vssType: String) on FIELD_DEFINITION | OBJECT
 

--- a/examples/trailer/modular_trailer_example/instances.graphql
+++ b/examples/trailer/modular_trailer_example/instances.graphql
@@ -1,5 +1,5 @@
 extend type VehicleTrailer {
-    instanceTag: TrailerTag
+    trailer: TrailerTag @instanceTag
 }
 
 type TrailerTag @instanceTag {
@@ -14,7 +14,7 @@ enum ThreeTrailers {
 }
 
 extend type VehicleTrailerAxle {
-    instanceTag: TrailerAxleTag
+    trailerAxle: TrailerAxleTag @instanceTag
 }
 
 type TrailerAxleTag @instanceTag {
@@ -40,7 +40,7 @@ enum AxlePositionEnum {
 }
 
 extend type VehicleTrailerWheel {
-    instanceTag: TrailerWheelTag
+    trailerWheel: TrailerWheelTag @instanceTag
 }
 
 type TrailerWheelTag @instanceTag {

--- a/src/s2dm/api/errors.py
+++ b/src/s2dm/api/errors.py
@@ -1,5 +1,7 @@
 """API-specific error types and translation helpers."""
 
+from collections.abc import Sequence
+
 import yaml
 from ariadne.exceptions import GraphQLFileSyntaxError
 from graphql import GraphQLError, GraphQLSyntaxError
@@ -15,12 +17,16 @@ class ResourceNotFoundError(FileNotFoundError):
     """Resource requested through the API does not exist."""
 
 
-def format_error_list(summary: str, errors: list[str]) -> str:
-    """Format multiple validation errors as a multiline message."""
+def format_error_list(summary: str, errors: Sequence[object]) -> str:
+    """Format multiple validation errors as a multiline message.
+
+    Accepts plain strings or any object whose ``str()`` is the error message
+    (e.g. ``ConstraintViolation``).
+    """
     if not errors:
         return summary
 
-    return f"{summary}:\n" + "\n".join(errors)
+    return f"{summary}:\n" + "\n".join(str(error) for error in errors)
 
 
 def to_response_error(exc: Exception) -> ResponseError | None:

--- a/src/s2dm/api/routes/linkml.py
+++ b/src/s2dm/api/routes/linkml.py
@@ -32,7 +32,7 @@ def export_linkml(request: LinkmlExportRequest) -> ApiResponse:
 
         schema_errors = check_correct_schema(annotated_schema.schema)
         if schema_errors:
-            raise ValueError(f"Schema validation failed: {'; '.join(schema_errors)}")
+            raise ValueError(f"Schema validation failed: {'; '.join(str(error) for error in schema_errors)}")
 
         linkml_content = translate_to_linkml(
             annotated_schema,

--- a/src/s2dm/cli.py
+++ b/src/s2dm/cli.py
@@ -74,6 +74,7 @@ from s2dm.exporters.utils.schema_loader import (
     load_schema,
     resolve_files_by_extensions,
 )
+from s2dm.exporters.utils.violations import Severity
 from s2dm.exporters.vspec import translate_to_vspec
 from s2dm.registry.concept_uris import create_concept_uri_model
 from s2dm.registry.search import NO_LIMIT_KEYWORDS, SearchResult, SKOSSearchService
@@ -1478,13 +1479,21 @@ def check_constraints(schemas: list[Path], naming_config: Path | None) -> None:
 
     constraint_checker = ConstraintChecker(gql_schema, naming_convention_config)
     violations = constraint_checker.run(objects)
+    warnings = [violation for violation in violations if violation.severity == Severity.WARNING]
+    errors = [violation for violation in violations if violation.severity == Severity.ERROR]
 
-    if violations:
+    if warnings:
+        log.rule("Constraint Warnings", style="bold yellow")
+        for warning in warnings:
+            log.warning(f"- {warning.message}")
+
+    if errors:
         log.rule("Constraint Violations", style="bold red")
-        for violation in violations:
-            log.error(f"- {violation.message}")
+        for error in errors:
+            log.error(f"- {error.message}")
         raise sys.exit(1)
-    else:
+
+    if not warnings:
         log.success("All constraints passed!")
 
 

--- a/src/s2dm/cli.py
+++ b/src/s2dm/cli.py
@@ -361,7 +361,7 @@ def assert_correct_schema(schema: GraphQLSchema) -> None:
     if schema_errors:
         log.error("Schema validation failed:")
         for error in schema_errors:
-            log.error(error)
+            log.error(error.message)
         log.error(f"Found {len(schema_errors)} validation error(s). Please fix the schema before exporting.")
         sys.exit(1)
 
@@ -1455,12 +1455,12 @@ def check_constraints(schemas: list[Path], naming_config: Path | None) -> None:
     naming_convention_config = load_naming_convention_config(naming_config, ValidationMode.CHECK)
 
     constraint_checker = ConstraintChecker(gql_schema, naming_convention_config)
-    errors = constraint_checker.run(objects)
+    violations = constraint_checker.run(objects)
 
-    if errors:
+    if violations:
         log.rule("Constraint Violations", style="bold red")
-        for err in errors:
-            log.error(f"- {err}")
+        for violation in violations:
+            log.error(f"- {violation.message}")
         raise sys.exit(1)
     else:
         log.success("All constraints passed!")

--- a/src/s2dm/cli.py
+++ b/src/s2dm/cli.py
@@ -1,3 +1,4 @@
+import functools
 import json
 import logging
 import os
@@ -408,6 +409,20 @@ def diff() -> None:
 def deps() -> None:
     """Dependency commands."""
     pass
+
+
+def handle_export_errors(func: Callable[..., Any]) -> Callable[..., Any]:
+    """Log expected export failures and exit non-zero, instead of leaking a traceback."""
+
+    @functools.wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        try:
+            return func(*args, **kwargs)
+        except (OSError, RuntimeError, TypeError, ValueError, GraphQLError, ValidationError, yaml.YAMLError) as error:
+            log.error(f"Export failed: {error}")
+            sys.exit(1)
+
+    return wrapper
 
 
 @click.group()
@@ -992,6 +1007,7 @@ def _compose_schemas(
     show_default=True,
 )
 @expanded_instances_option
+@handle_export_errors
 def shacl(
     schemas: list[Path],
     selection_query: Path | None,
@@ -1035,6 +1051,7 @@ def shacl(
 @root_type_option
 @naming_config_option
 @expanded_instances_option
+@handle_export_errors
 def vspec(
     schemas: list[Path],
     selection_query: Path | None,
@@ -1085,6 +1102,7 @@ def vspec(
     required=True,
     help="LinkML default prefix URL",
 )
+@handle_export_errors
 def linkml(
     schemas: list[Path],
     selection_query: Path | None,
@@ -1127,6 +1145,7 @@ def linkml(
 @naming_config_option
 @strict_option
 @expanded_instances_option
+@handle_export_errors
 def jsonschema(
     schemas: list[Path],
     selection_query: Path | None,
@@ -1166,6 +1185,7 @@ def avro() -> None:
 @naming_config_option
 @avro_namespace_option
 @expanded_instances_option
+@handle_export_errors
 def schema(
     schemas: list[Path],
     selection_query: Path,
@@ -1204,6 +1224,7 @@ def schema(
 @avro_namespace_option
 @expanded_instances_option
 @strict_option
+@handle_export_errors
 def protocol(
     schemas: list[Path],
     selection_query: Path | None,
@@ -1257,6 +1278,7 @@ def protocol(
     help="Protobuf package name",
 )
 @expanded_instances_option
+@handle_export_errors
 def protobuf(
     schemas: list[Path],
     selection_query: Path,

--- a/src/s2dm/constants/directive.py
+++ b/src/s2dm/constants/directive.py
@@ -1,0 +1,35 @@
+"""Names of the GraphQL directives and arguments used across the tool."""
+
+from enum import Enum
+
+
+class Directive(str, Enum):
+    """Names of the custom GraphQL directives used across the tool."""
+
+    INSTANCE_TAG = "instanceTag"
+    RANGE = "range"
+    CARDINALITY = "cardinality"
+    NO_DUPLICATES = "noDuplicates"
+    METADATA = "metadata"
+    REFERENCE = "reference"
+    VSPEC = "vspec"
+
+
+class BuiltInDirective(str, Enum):
+    """Names of the built-in GraphQL directives the tool reasons about."""
+
+    DEPRECATED = "deprecated"
+    SPECIFIED_BY = "specifiedBy"
+
+
+class DirectiveArgument(str, Enum):
+    """Names of the arguments accepted by the directives the tool reads."""
+
+    MIN = "min"
+    MAX = "max"
+    COMMENT = "comment"
+    VSS_TYPE = "vssType"
+    URI = "uri"
+    SOURCE = "source"
+    ELEMENT = "element"
+    METADATA = "metadata"

--- a/src/s2dm/constants/directive.py
+++ b/src/s2dm/constants/directive.py
@@ -25,6 +25,7 @@ class BuiltInDirective(str, Enum):
 class DirectiveArgument(str, Enum):
     """Names of the arguments accepted by the directives the tool reads."""
 
+    EXCLUDE = "exclude"
     MIN = "min"
     MAX = "max"
     COMMENT = "comment"

--- a/src/s2dm/deps/resolve/resolvers/remote_resolver.py
+++ b/src/s2dm/deps/resolve/resolvers/remote_resolver.py
@@ -224,7 +224,7 @@ class RemoteResolver(Resolver):
     ) -> str:
         if asset_name is None:
             return f"Failed to load dependency release metadata for '{repository}' version '{version}': {error}"
-        return f"Failed to download dependency asset '{asset_name}' for '{repository}' " f"version '{version}': {error}"
+        return f"Failed to download dependency asset '{asset_name}' for '{repository}' version '{version}': {error}"
 
     def _build_resource_label(self, asset_name: str | None) -> str:
         if asset_name is None:

--- a/src/s2dm/exporters/README.md
+++ b/src/s2dm/exporters/README.md
@@ -88,7 +88,7 @@ type Cabin {
 }
 
 type Seat {
-  instanceTag: InCabinArea2x2
+  inCabinArea: InCabinArea2x2 @instanceTag
   position(unit: Length_Unit_Enum = MILLIMETER): UInt16
     @metadata(vssType: "actuator")
 }
@@ -223,7 +223,7 @@ type Cabin {
 }
 
 type Door {
-  instanceTag: Area2x2
+  area: Area2x2 @instanceTag
 }
 
 type Area2x2 @instanceTag {

--- a/src/s2dm/exporters/avro/common.py
+++ b/src/s2dm/exporters/avro/common.py
@@ -1,5 +1,6 @@
 from graphql import GraphQLField, GraphQLScalarType
 
+from s2dm.constants.directive import Directive, DirectiveArgument
 from s2dm.exporters.utils.directive import get_directive_arguments, has_given_directive
 
 INT32_MIN = -(2**31)
@@ -25,10 +26,10 @@ def get_avro_scalar_type(scalar_type: GraphQLScalarType, field: GraphQLField | N
     """Get Avro type for a GraphQL scalar, considering @range directive."""
     base_type = GRAPHQL_SCALAR_TO_AVRO.get(scalar_type.name, "string")
 
-    if field and base_type in ("int", "long") and has_given_directive(field, "range"):
-        range_args = get_directive_arguments(field, "range")
+    if field and base_type in ("int", "long") and has_given_directive(field, Directive.RANGE):
+        range_args = get_directive_arguments(field, Directive.RANGE)
 
-        for key in ("min", "max"):
+        for key in (DirectiveArgument.MIN, DirectiveArgument.MAX):
             if key in range_args:
                 val = range_args[key]
                 if val < INT32_MIN or val > INT32_MAX:

--- a/src/s2dm/exporters/avro/protocol.py
+++ b/src/s2dm/exporters/avro/protocol.py
@@ -1,7 +1,7 @@
 from typing import cast
 
 from graphql import GraphQLNamedType, GraphQLObjectType, is_named_type
-from graphql.language.ast import ListValueNode, ObjectValueNode, StringValueNode
+from graphql.language.ast import ObjectValueNode, StringValueNode
 
 from s2dm import log
 from s2dm.constants.directive import Directive, DirectiveArgument
@@ -19,10 +19,10 @@ def get_namespace_from_metadata(object_type: GraphQLObjectType, global_namespace
     """Extract namespace from @vspec metadata key-value pairs, fallback to global."""
     metadata = get_argument_content(object_type, Directive.VSPEC, DirectiveArgument.METADATA)
 
-    if not metadata or not isinstance(metadata, ListValueNode):
+    if not metadata or not isinstance(metadata, list):
         return global_namespace
 
-    for item in metadata.values:
+    for item in metadata:
         if not isinstance(item, ObjectValueNode):
             continue
 

--- a/src/s2dm/exporters/avro/protocol.py
+++ b/src/s2dm/exporters/avro/protocol.py
@@ -4,6 +4,7 @@ from graphql import GraphQLNamedType, GraphQLObjectType, is_named_type
 from graphql.language.ast import ListValueNode, ObjectValueNode, StringValueNode
 
 from s2dm import log
+from s2dm.constants.directive import Directive, DirectiveArgument
 from s2dm.exporters.utils.annotated_schema import AnnotatedSchema
 from s2dm.exporters.utils.directive import get_argument_content
 from s2dm.exporters.utils.extraction import get_all_object_types, get_all_objects_with_directive
@@ -11,13 +12,12 @@ from s2dm.exporters.utils.schema_loader import get_referenced_types
 
 from .protocol_transformer import AvroProtocolTransformer
 
-VSPEC_DIRECTIVE = "vspec"
 STRUCT_ELEMENT = "STRUCT"
 
 
 def get_namespace_from_metadata(object_type: GraphQLObjectType, global_namespace: str) -> str:
     """Extract namespace from @vspec metadata key-value pairs, fallback to global."""
-    metadata = get_argument_content(object_type, VSPEC_DIRECTIVE, "metadata")
+    metadata = get_argument_content(object_type, Directive.VSPEC, DirectiveArgument.METADATA)
 
     if not metadata or not isinstance(metadata, ListValueNode):
         return global_namespace
@@ -61,14 +61,14 @@ def _generate_protocol_for_struct_types(
     """
     schema = annotated_schema.schema
     all_objects = get_all_object_types(schema)
-    vspec_types = get_all_objects_with_directive(all_objects, VSPEC_DIRECTIVE)
+    vspec_types = get_all_objects_with_directive(all_objects, Directive.VSPEC)
     struct_types = [
         vspec_type
         for vspec_type in vspec_types
-        if get_argument_content(vspec_type, VSPEC_DIRECTIVE, "element") == STRUCT_ELEMENT
+        if get_argument_content(vspec_type, Directive.VSPEC, DirectiveArgument.ELEMENT) == STRUCT_ELEMENT
     ]
 
-    log.info(f"Found {len(struct_types)} types with @{VSPEC_DIRECTIVE}(element: {STRUCT_ELEMENT}) directive")
+    log.info(f"Found {len(struct_types)} types with @{Directive.VSPEC.value}(element: {STRUCT_ELEMENT}) directive")
 
     protocols: dict[str, str] = {}
 

--- a/src/s2dm/exporters/jsonschema/transformer.py
+++ b/src/s2dm/exporters/jsonschema/transformer.py
@@ -22,15 +22,12 @@ from graphql import (
 )
 
 from s2dm import log
+from s2dm.constants.directive import Directive, DirectiveArgument
 from s2dm.exporters.utils.annotated_schema import TypeMetadata
 from s2dm.exporters.utils.directive import get_directive_arguments, has_given_directive
 from s2dm.exporters.utils.extraction import get_all_named_types
 from s2dm.exporters.utils.field import get_cardinality
 from s2dm.exporters.utils.graphql_type import is_root_type
-from s2dm.exporters.utils.instance_tag import (
-    is_instance_tag_field,
-    is_valid_instance_tag_field,
-)
 
 GRAPHQL_SCALAR_TO_JSON_SCHEMA = {
     "String": "string",
@@ -165,14 +162,8 @@ class JsonSchemaTransformer:
         Returns:
             Optional[Dict[str, Any]]: JSON Schema definition or None if not transformable
         """
-        if is_object_type(graphql_type) and not has_given_directive(
-            cast(GraphQLObjectType, graphql_type), "instanceTag"
-        ):
+        if is_object_type(graphql_type):
             return self.transform_object_type(cast(GraphQLObjectType, graphql_type))
-        elif is_object_type(graphql_type) and has_given_directive(cast(GraphQLObjectType, graphql_type), "instanceTag"):
-            object_type = cast(GraphQLObjectType, graphql_type)
-            log.warning(f"Skipping object type with @instanceTag directive: {object_type.name}")
-            return None
         elif is_enum_type(graphql_type):
             return self.transform_enum_type(cast(GraphQLEnumType, graphql_type))
         elif is_interface_type(graphql_type):
@@ -211,14 +202,6 @@ class JsonSchemaTransformer:
 
         required_fields = []
         for field_name, field in object_type.fields.items():
-            if is_valid_instance_tag_field(field, self.graphql_schema):
-                if is_instance_tag_field(field_name):
-                    continue
-                else:
-                    raise ValueError(
-                        f"Invalid schema: instanceTag object found on non-instanceTag named field '{field_name}'"
-                    )
-
             target_type_name = get_named_type(field.type).name
             if self._is_intermediate(target_type_name):
                 # Inline the expansion structure; never add to required (matches previous output)
@@ -413,7 +396,7 @@ class JsonSchemaTransformer:
         field_extensions: dict[str, Any] = {}
         contained_type_extensions: dict[str, Any] = {}
 
-        if has_given_directive(element, "noDuplicates"):
+        if has_given_directive(element, Directive.NO_DUPLICATES):
             field_extensions["uniqueItems"] = True
 
         if isinstance(element, GraphQLField):
@@ -424,13 +407,13 @@ class JsonSchemaTransformer:
                 if cardinality.max is not None:
                     field_extensions["maxItems"] = cardinality.max
 
-        if has_given_directive(element, "range"):
-            args = get_directive_arguments(element, "range")
+        if has_given_directive(element, Directive.RANGE):
+            args = get_directive_arguments(element, Directive.RANGE)
             range_extensions = {}
-            if "min" in args:
-                range_extensions["minimum"] = args["min"]
-            if "max" in args:
-                range_extensions["maximum"] = args["max"]
+            if DirectiveArgument.MIN in args:
+                range_extensions["minimum"] = args[DirectiveArgument.MIN]
+            if DirectiveArgument.MAX in args:
+                range_extensions["maximum"] = args[DirectiveArgument.MAX]
 
             unwrapped_type = field_type
             if unwrapped_type and is_non_null_type(unwrapped_type):
@@ -441,11 +424,11 @@ class JsonSchemaTransformer:
             else:
                 field_extensions.update(range_extensions)
 
-        if has_given_directive(element, "metadata"):
-            args = get_directive_arguments(element, "metadata")
-            if "comment" in args:
-                field_extensions["$comment"] = args["comment"]
-            other_metadata = {k: v for k, v in args.items() if k != "comment"}
+        if has_given_directive(element, Directive.METADATA):
+            args = get_directive_arguments(element, Directive.METADATA)
+            if DirectiveArgument.COMMENT in args:
+                field_extensions["$comment"] = args[DirectiveArgument.COMMENT]
+            other_metadata = {k: v for k, v in args.items() if k != DirectiveArgument.COMMENT}
             if other_metadata:
                 field_extensions["x-metadata"] = other_metadata
 

--- a/src/s2dm/exporters/linkml/transformer.py
+++ b/src/s2dm/exporters/linkml/transformer.py
@@ -32,6 +32,7 @@ from linkml_runtime.linkml_model.meta import (
 from linkml_runtime.linkml_model.units import UnitOfMeasure
 from linkml_runtime.utils.schema_as_dict import schema_as_dict
 
+from s2dm.constants.directive import Directive, DirectiveArgument
 from s2dm.exporters.utils.annotated_schema import AnnotatedSchema
 from s2dm.exporters.utils.directive import get_argument_content, get_directive_arguments, has_given_directive
 from s2dm.exporters.utils.field import FieldCase, get_cardinality, get_field_case
@@ -160,7 +161,7 @@ class LinkmlTransformer:
             permissible_values: dict[str, PermissibleValue] = {}
             for enum_value_name, enum_value in named_type.values.items():
                 permissible_value = PermissibleValue(text=enum_value_name)
-                meaning = get_argument_content(enum_value, "reference", "uri")
+                meaning = get_argument_content(enum_value, Directive.REFERENCE, DirectiveArgument.URI)
                 if meaning:
                     permissible_value.meaning = meaning
                 permissible_values[enum_value_name] = permissible_value
@@ -171,7 +172,7 @@ class LinkmlTransformer:
             )
             if named_type.description:
                 enum_definition.description = named_type.description
-            enum_uri = get_argument_content(named_type, "reference", "uri")
+            enum_uri = get_argument_content(named_type, Directive.REFERENCE, DirectiveArgument.URI)
             if enum_uri:
                 enum_definition.exact_mappings = [enum_uri]
             enum_definitions[named_type.name] = enum_definition
@@ -305,9 +306,11 @@ class LinkmlTransformer:
         field: GraphQLField | GraphQLInputField,
         multivalued: bool,
     ) -> None:
-        range_arguments = get_directive_arguments(field, "range") if has_given_directive(field, "range") else {}
-        min_value = range_arguments.get("min")
-        max_value = range_arguments.get("max")
+        range_arguments = (
+            get_directive_arguments(field, Directive.RANGE) if has_given_directive(field, Directive.RANGE) else {}
+        )
+        min_value = range_arguments.get(DirectiveArgument.MIN)
+        max_value = range_arguments.get(DirectiveArgument.MAX)
         if isinstance(min_value, int | float):
             slot_definition.minimum_value = min_value
         if isinstance(max_value, int | float):
@@ -320,7 +323,7 @@ class LinkmlTransformer:
             if cardinality.max is not None:
                 slot_definition.maximum_cardinality = cardinality.max
 
-        if multivalued and has_given_directive(field, "noDuplicates"):
+        if multivalued and has_given_directive(field, Directive.NO_DUPLICATES):
             slot_definition.list_elements_unique = True
 
     def _apply_unit_mapping(self, slot_definition: SlotDefinition, field: GraphQLField | GraphQLInputField) -> None:
@@ -346,11 +349,11 @@ class LinkmlTransformer:
         unit_symbol, enum_value = enum_match
         unit_payload: dict[str, Any] = {"symbol": unit_symbol}
 
-        unit_uri = get_argument_content(enum_value, "reference", "uri")
+        unit_uri = get_argument_content(enum_value, Directive.REFERENCE, DirectiveArgument.URI)
         if unit_uri:
             unit_payload["exact_mappings"] = [unit_uri]
 
-        quantity_kind_uri = get_argument_content(unit_type, "reference", "uri")
+        quantity_kind_uri = get_argument_content(unit_type, Directive.REFERENCE, DirectiveArgument.URI)
         if quantity_kind_uri:
             unit_payload["has_quantity_kind"] = quantity_kind_uri
 
@@ -380,10 +383,10 @@ class LinkmlTransformer:
         | GraphQLInputObjectType
         | GraphQLInterfaceType,
     ) -> None:
-        if not has_given_directive(source_element, "metadata"):
+        if not has_given_directive(source_element, Directive.METADATA):
             return
 
-        metadata_arguments = get_directive_arguments(source_element, "metadata")
+        metadata_arguments = get_directive_arguments(source_element, Directive.METADATA)
         annotations = {
             f"s2dm_metadata_{key}": self._stringify_directive_value(value)
             for key, value in metadata_arguments.items()

--- a/src/s2dm/exporters/protobuf/transformer.py
+++ b/src/s2dm/exporters/protobuf/transformer.py
@@ -24,6 +24,7 @@ from graphql import (
 from jinja2 import Environment, PackageLoader, select_autoescape
 
 from s2dm import log
+from s2dm.constants.directive import Directive, DirectiveArgument
 from s2dm.exporters.protobuf.models import ProtoEnum, ProtoEnumValue, ProtoField, ProtoMessage, ProtoSchema, ProtoUnion
 from s2dm.exporters.utils.annotated_schema import AnnotatedSchema
 from s2dm.exporters.utils.directive import get_directive_arguments, has_given_directive
@@ -479,7 +480,7 @@ class ProtobufTransformer:
         repeated_rules = []
         is_repeated = "repeated" in proto_type
 
-        if has_given_directive(field, "noDuplicates"):
+        if has_given_directive(field, Directive.NO_DUPLICATES):
             unwrapped_type = get_named_type(field.type)
             if is_scalar_type(unwrapped_type) or is_enum_type(unwrapped_type):
                 repeated_rules.append("unique: true")
@@ -491,15 +492,15 @@ class ProtobufTransformer:
             if cardinality.max is not None:
                 repeated_rules.append(f"max_items: {cardinality.max}")
 
-        if has_given_directive(field, "range"):
-            args = get_directive_arguments(field, "range")
+        if has_given_directive(field, Directive.RANGE):
+            args = get_directive_arguments(field, Directive.RANGE)
             scalar_type = self._get_validation_type(proto_type)
             if scalar_type:
                 range_rules = []
-                if "min" in args:
-                    range_rules.append(f"gte: {args['min']}")
-                if "max" in args:
-                    range_rules.append(f"lte: {args['max']}")
+                if DirectiveArgument.MIN in args:
+                    range_rules.append(f"gte: {args[DirectiveArgument.MIN]}")
+                if DirectiveArgument.MAX in args:
+                    range_rules.append(f"lte: {args[DirectiveArgument.MAX]}")
                 if range_rules:
                     if is_repeated:
                         repeated_rules.append(f"items: {{{scalar_type}: {{{', '.join(range_rules)}}}}}")

--- a/src/s2dm/exporters/shacl.py
+++ b/src/s2dm/exporters/shacl.py
@@ -13,6 +13,7 @@ from rdflib import RDF, RDFS, SH, XSD, BNode, Graph, Literal, Namespace, Node, U
 from rdflib.collection import Collection
 
 from s2dm import log
+from s2dm.constants.directive import Directive, DirectiveArgument
 from s2dm.exporters.utils.annotated_schema import AnnotatedSchema
 from s2dm.exporters.utils.directive import get_argument_content
 from s2dm.exporters.utils.extraction import get_all_object_types
@@ -45,7 +46,7 @@ def get_xsd_datatype(scalar: GraphQLScalarType) -> URIRef:
 
 def add_comment_to_property_node(field: GraphQLField, property_node: BNode, graph: Graph) -> None:
     """Add comment metadata to a property node if it exists."""
-    comment = get_argument_content(field, "metadata", "comment")
+    comment = get_argument_content(field, Directive.METADATA, DirectiveArgument.COMMENT)
     if comment and comment != {}:
         _ = graph.add((property_node, RDFS.comment, Literal(comment)))
 

--- a/src/s2dm/exporters/utils/directive.py
+++ b/src/s2dm/exporters/utils/directive.py
@@ -19,6 +19,8 @@ from graphql import (
 )
 from graphql.language.printer import print_ast
 
+from s2dm.constants.directive import BuiltInDirective
+
 GRAPHQL_TYPE_DEFINITION_PATTERN = r"^(type|interface|input|enum|union|scalar)\s+(\w+)"
 
 DirectiveElement = (
@@ -89,6 +91,48 @@ def has_given_directive(element: DirectiveElement, directive_name: str) -> bool:
     return False
 
 
+def get_field_with_applied_directive(
+    object_type: GraphQLObjectType, directive_to_check: str
+) -> dict[str, GraphQLField]:
+    """
+    Collect all fields of an object type that have the given directive applied.
+
+    Args:
+        object_type: The object type whose fields are inspected.
+        directive_to_check: The name of the directive to look for on each field.
+
+    Returns:
+        dict[str, GraphQLField]: A mapping of field name to field for every field carrying the directive.
+    """
+    return {
+        field_name: field
+        for field_name, field in object_type.fields.items()
+        if has_given_directive(field, directive_to_check)
+    }
+
+
+def get_objects_with_multiple_fields_with_directive(
+    object_types: list[GraphQLObjectType], directive_to_check: str
+) -> dict[str, list[str]]:
+    """
+    Find object types that declare more than one field with the given directive applied.
+
+    Args:
+        object_types: The object types to inspect.
+        directive_to_check: The name of the directive to look for on each field.
+
+    Returns:
+        dict[str, list[str]]: Mapping of object type name to its matching field names,
+        for each object type that declares more than one such field.
+    """
+    objects: dict[str, list[str]] = {}
+    for object_type in object_types:
+        fields_with_directive = list(get_field_with_applied_directive(object_type, directive_to_check))
+        if len(fields_with_directive) > 1:
+            objects[object_type.name] = fields_with_directive
+    return objects
+
+
 def get_argument_content(element: DirectiveElement, directive_name: str, argument_name: str) -> Any | None:
     """
     Extracts the comment from a GraphQL element (field or named type).
@@ -107,7 +151,7 @@ def get_argument_content(element: DirectiveElement, directive_name: str, argumen
 
 def format_directive_from_ast(directive_node: Any) -> str:
     directive_name = directive_node.name.value
-    if directive_name in {"deprecated", "specifiedBy"}:
+    if directive_name in {BuiltInDirective.DEPRECATED, BuiltInDirective.SPECIFIED_BY}:
         return ""
 
     args_str = ""

--- a/src/s2dm/exporters/utils/directive.py
+++ b/src/s2dm/exporters/utils/directive.py
@@ -16,6 +16,7 @@ from graphql import (
     GraphQLType,
     GraphQLUnionType,
     IntValueNode,
+    ListValueNode,
 )
 from graphql.language.printer import print_ast
 
@@ -66,18 +67,25 @@ def get_directive_arguments(element: DirectiveElement, directive_name: str) -> d
     directive = next(d for d in element.ast_node.directives if d.name.value == directive_name)
     args: dict[str, Any] = {}
 
+    def convert_value(value_node: Any) -> Any:
+        if isinstance(value_node, IntValueNode):
+            return int(value_node.value)
+
+        if isinstance(value_node, FloatValueNode):
+            return float(value_node.value)
+
+        if isinstance(value_node, ListValueNode):
+            return [convert_value(item) for item in value_node.values]
+
+        raw_value = getattr(value_node, "value", None)
+        if raw_value is not None:
+            return raw_value
+
+        return value_node
+
     for arg in directive.arguments:
         arg_name = arg.name.value
-        value_node: Any = arg.value
-        raw_value = getattr(value_node, "value", None)
-        if isinstance(value_node, IntValueNode):
-            args[arg_name] = int(value_node.value)
-        elif isinstance(value_node, FloatValueNode):
-            args[arg_name] = float(value_node.value)
-        elif raw_value is not None:
-            args[arg_name] = raw_value
-        else:
-            args[arg_name] = value_node
+        args[arg_name] = convert_value(arg.value)
 
     return args
 

--- a/src/s2dm/exporters/utils/field.py
+++ b/src/s2dm/exporters/utils/field.py
@@ -3,6 +3,7 @@ from enum import Enum
 
 from graphql import GraphQLField, GraphQLInputField, is_list_type, is_non_null_type
 
+from s2dm.constants.directive import Directive, DirectiveArgument
 from s2dm.exporters.utils.directive import get_directive_arguments, has_given_directive
 
 
@@ -133,7 +134,7 @@ def get_field_case_extended(field: GraphQLField) -> FieldCase:
         FieldCase: The case of the field as one of (6 base + custom ones).
     """
     base_case = get_field_case(field)
-    if has_given_directive(field, "noDuplicates"):
+    if has_given_directive(field, Directive.NO_DUPLICATES):
         if base_case == FieldCase.LIST:
             return FieldCase.SET
         elif base_case == FieldCase.LIST_NON_NULL:
@@ -157,13 +158,21 @@ def get_cardinality(field: GraphQLField | GraphQLInputField) -> Cardinality | No
     Returns:
         Cardinality | None: The Cardinality if the directive is present, otherwise None.
     """
-    if has_given_directive(field, "cardinality"):
-        args = get_directive_arguments(field, "cardinality")
+    if has_given_directive(field, Directive.CARDINALITY):
+        args = get_directive_arguments(field, Directive.CARDINALITY)
         min_val = None
         max_val = None
         if args:
-            min_val = int(args["min"]) if "min" in args and args["min"] is not None else None
-            max_val = int(args["max"]) if "max" in args and args["max"] is not None else None
+            min_val = (
+                int(args[DirectiveArgument.MIN])
+                if DirectiveArgument.MIN in args and args[DirectiveArgument.MIN] is not None
+                else None
+            )
+            max_val = (
+                int(args[DirectiveArgument.MAX])
+                if DirectiveArgument.MAX in args and args[DirectiveArgument.MAX] is not None
+                else None
+            )
         return Cardinality(min=min_val, max=max_val)
     else:
         return None

--- a/src/s2dm/exporters/utils/instance_tag.py
+++ b/src/s2dm/exporters/utils/instance_tag.py
@@ -13,15 +13,16 @@ from graphql import (
 )
 
 from s2dm import log
+from s2dm.constants.directive import Directive
 from s2dm.exporters.utils.annotated_schema import FieldMetadata, TypeMetadata
-from s2dm.exporters.utils.directive import has_given_directive
+from s2dm.exporters.utils.directive import get_field_with_applied_directive, has_given_directive
 from s2dm.exporters.utils.extraction import get_all_object_types, get_all_objects_with_directive
 from s2dm.exporters.utils.naming import apply_naming_to_instance_values, convert_name
 from s2dm.exporters.utils.naming_config import ContextType, ElementType, NamingConventionConfig, get_case_for_element
 
 
-def is_instance_tag_field(field_name: str) -> bool:
-    return field_name == "instanceTag"
+def is_instance_tag_field(field: GraphQLField) -> bool:
+    return has_given_directive(field, Directive.INSTANCE_TAG)
 
 
 def get_all_expanded_instance_tags(
@@ -29,7 +30,7 @@ def get_all_expanded_instance_tags(
     naming_config: NamingConventionConfig | None = None,
 ) -> dict[GraphQLObjectType, list[str]]:
     all_expanded_instance_tags: dict[GraphQLObjectType, list[str]] = {}
-    for object in get_all_objects_with_directive(get_all_object_types(schema), "instanceTag"):
+    for object in get_all_objects_with_directive(get_all_object_types(schema), Directive.INSTANCE_TAG):
         all_expanded_instance_tags[object] = expand_instance_tag(object, naming_config)
 
     log.debug(f"All expanded tags in the spec: {all_expanded_instance_tags}")
@@ -40,7 +41,7 @@ def get_all_expanded_instance_tags(
 def expand_instance_tag(object: GraphQLObjectType, naming_config: NamingConventionConfig | None = None) -> list[str]:
     log.debug(f"Expanding instanceTag for object: {object.name}")
     expanded_tags = []
-    if not has_given_directive(object, "instanceTag"):
+    if not has_given_directive(object, Directive.INSTANCE_TAG):
         raise ValueError(f"Object '{object.name}' does not have an instance tag directive.")
     else:
         tags_per_enum_field = []
@@ -67,8 +68,9 @@ def expand_instance_tag(object: GraphQLObjectType, naming_config: NamingConventi
 
 def is_valid_instance_tag_field(field: GraphQLField, schema: GraphQLSchema) -> bool:
     """
-    Check if the output type of the given field is a valid instanceTag.
-    A valid instanceTag is an object type with the @instanceTag directive.
+    Check if the given field is a valid instanceTag field.
+    A valid instanceTag field is annotated with @instanceTag and references an
+    object type with the @instanceTag directive.
 
     Args:
         field (GraphQLField): The field to check.
@@ -77,14 +79,16 @@ def is_valid_instance_tag_field(field: GraphQLField, schema: GraphQLSchema) -> b
     Returns:
         bool: True if the field's output type is a valid instanceTag, False otherwise.
     """
+    if not is_instance_tag_field(field):
+        return False
+
     output_type = schema.get_type(get_named_type(field.type).name)
-    return isinstance(output_type, GraphQLObjectType) and has_given_directive(output_type, "instanceTag")
+    return isinstance(output_type, GraphQLObjectType) and has_given_directive(output_type, Directive.INSTANCE_TAG)
 
 
 def has_valid_instance_tag_field(object_type: GraphQLObjectType, schema: GraphQLSchema) -> bool:
     """
-    Check if a given object type has a field named 'instanceTag' and if the field's output type
-    is a valid instanceTag.
+    Check if a given object type has a valid instanceTag field.
 
     Args:
         object_type (GraphQLObjectType): The object type to check.
@@ -93,13 +97,25 @@ def has_valid_instance_tag_field(object_type: GraphQLObjectType, schema: GraphQL
     Returns:
         bool: True if the object type has a valid instanceTag field, False otherwise.
     """
-    if "instanceTag" in object_type.fields:
-        log.debug(f"instanceTag? {True}")
-        field = object_type.fields["instanceTag"]
-        return is_valid_instance_tag_field(field, schema)
-    else:
-        log.debug(f"instanceTag? {False}")
-        return False
+    return get_instance_tag_field_name(object_type, schema) is not None
+
+
+def get_instance_tag_field_name(object_type: GraphQLObjectType, schema: GraphQLSchema) -> str | None:
+    """
+    Get the name of the field annotated with a valid @instanceTag directive.
+
+    Args:
+        object_type (GraphQLObjectType): The object type to inspect.
+        schema (GraphQLSchema): The GraphQL schema to validate against.
+
+    Returns:
+        str | None: The name of the valid instanceTag field if found, None otherwise.
+    """
+    instance_tag_fields = get_field_with_applied_directive(object_type, Directive.INSTANCE_TAG)
+    for field_name, field in instance_tag_fields.items():
+        if is_valid_instance_tag_field(field, schema):
+            return field_name
+    return None
 
 
 def get_instance_tag_object(object_type: GraphQLObjectType, schema: GraphQLSchema) -> GraphQLObjectType | None:
@@ -113,15 +129,14 @@ def get_instance_tag_object(object_type: GraphQLObjectType, schema: GraphQLSchem
     Returns:
         GraphQLObjectType | None: The valid instance tag object type if found, None otherwise.
     """
+    field_name = get_instance_tag_field_name(object_type, schema)
+    if field_name is None:
+        return None
 
-    instance_tag_field_name = "instanceTag"
-    if instance_tag_field_name in object_type.fields:
-        field = object_type.fields[instance_tag_field_name]
-        instance_tag_type = schema.get_type(get_named_type(field.type).name)
-        if isinstance(
-            instance_tag_type, GraphQLObjectType
-        ):  # and has_given_directive(instance_tag_type, instance_tag_field_name):
-            return instance_tag_type
+    field = object_type.fields[field_name]
+    instance_tag_type = schema.get_type(get_named_type(field.type).name)
+    if isinstance(instance_tag_type, GraphQLObjectType):
+        return instance_tag_type
     return None
 
 
@@ -336,12 +351,14 @@ def expand_instances_in_schema(
         base_types_to_clean.add(base_type)
 
     all_types_to_remove = set(instance_tag_types_to_remove)
-    all_instance_tag_types = get_all_objects_with_directive(get_all_object_types(schema), "instanceTag")
+    all_instance_tag_types = get_all_objects_with_directive(get_all_object_types(schema), Directive.INSTANCE_TAG)
     all_types_to_remove.update(t.name for t in all_instance_tag_types)
 
     for base_type in base_types_to_clean:
-        del base_type.fields["instanceTag"]
-        log.debug(f"Removed 'instanceTag' field from type '{base_type.name}'")
+        tag_field_name = get_instance_tag_field_name(base_type, schema)
+        if tag_field_name is not None:
+            del base_type.fields[tag_field_name]
+            log.debug(f"Removed '{tag_field_name}' instanceTag field from type '{base_type.name}'")
 
     for type_name in all_types_to_remove:
         if type_name in schema.type_map:

--- a/src/s2dm/exporters/utils/instance_tag.py
+++ b/src/s2dm/exporters/utils/instance_tag.py
@@ -8,6 +8,7 @@ from graphql import (
     GraphQLObjectType,
     GraphQLSchema,
     get_named_type,
+    get_nullable_type,
     is_list_type,
     is_non_null_type,
 )
@@ -42,7 +43,6 @@ class _ExpandableField(NamedTuple):
     source_type_name: str
     instance_tag_dict: dict[str, list[str]]
     leaf_nullable: bool
-    is_list: bool
     original_field: GraphQLField
     exclude: list[str]
 
@@ -89,7 +89,7 @@ def is_valid_instance_tag_field(field: GraphQLField, schema: GraphQLSchema) -> b
     return get_instance_tag_type(field, schema) is not None
 
 
-def _resolve_instance_tag(object_type: GraphQLObjectType, schema: GraphQLSchema) -> _ResolvedInstanceTag | None:
+def resolve_instance_tag(object_type: GraphQLObjectType, schema: GraphQLSchema) -> _ResolvedInstanceTag | None:
     """
     Resolve the single valid @instanceTag field of an object type.
 
@@ -156,23 +156,29 @@ def get_instance_tag_dict(
     return instance_tag_dict
 
 
-def _collect_expandable_fields(schema: GraphQLSchema) -> list[_ExpandableField]:
-    """Find every field whose base type carries a valid instanceTag, without touching the schema."""
+def get_instance_tag_case(naming_config: NamingConventionConfig | None) -> CaseFormat | None:
+    """Return the configured case for instanceTag values, or None when unconfigured."""
+    if naming_config is None:
+        return None
+    return get_case_for_element(ElementType.INSTANCE_TAG, None, naming_config)
+
+
+def collect_expandable_fields(schema: GraphQLSchema) -> list[_ExpandableField]:
+    """Find every list field whose item type carries a valid instanceTag, without touching the schema."""
     expandable_fields = []
     for parent_type in get_all_object_types(schema):
         for field_name, field in parent_type.fields.items():
             base_type = get_named_type(field.type)
             if not isinstance(base_type, GraphQLObjectType):
                 continue
-            resolved = _resolve_instance_tag(base_type, schema)
+            resolved = resolve_instance_tag(base_type, schema)
             if resolved is None:
                 continue
 
-            unwrapped = field.type
-            if is_non_null_type(unwrapped):
-                unwrapped = unwrapped.of_type
-            is_list = is_list_type(unwrapped)
-            item_type = unwrapped.of_type if is_list else unwrapped
+            unwrapped = get_nullable_type(field.type)
+            if not is_list_type(unwrapped):
+                continue
+            item_type = unwrapped.of_type
 
             tag_field = base_type.fields[resolved.field_name]
             field_exclude = get_argument_content(tag_field, Directive.INSTANCE_TAG, DirectiveArgument.EXCLUDE) or []
@@ -190,7 +196,6 @@ def _collect_expandable_fields(schema: GraphQLSchema) -> list[_ExpandableField]:
                     source_type_name=resolved.source_type.name,
                     instance_tag_dict=_tag_dimensions_from_source(resolved.field_name, resolved.source_type),
                     leaf_nullable=not is_non_null_type(item_type),
-                    is_list=is_list,
                     original_field=field,
                     exclude=exclude,
                 )
@@ -198,7 +203,7 @@ def _collect_expandable_fields(schema: GraphQLSchema) -> list[_ExpandableField]:
     return expandable_fields
 
 
-def _included_instances(
+def included_instances(
     expandable: _ExpandableField,
     instance_tag_case: CaseFormat | None,
 ) -> list[tuple[str, ...]]:
@@ -326,8 +331,7 @@ def _apply_expansion(
             intermediate_type.name = convert_name(intermediate_type.name, type_case)
         new_types[intermediate_type.name] = intermediate_type
 
-    base_name = expandable.base_type.name if expandable.is_list else expandable.field_name
-    new_field_name = convert_name(base_name, field_case) if field_case else base_name
+    new_field_name = convert_name(expandable.base_type.name, field_case) if field_case else expandable.base_type.name
 
     field_metadata[(expandable.parent_type.name, new_field_name)] = FieldMetadata(
         resolved_names=[f"{new_field_name}.{'.'.join(instance)}" for instance in instances],
@@ -346,13 +350,11 @@ def _apply_expansion(
 
 
 def _cleanup_instance_tag_artifacts(schema: GraphQLSchema, expandable_fields: list[_ExpandableField]) -> None:
-    """Remove the instanceTag source types and the now-redundant instanceTag fields on base types."""
-    types_to_remove = {
-        type_obj.name
-        for type_obj in schema.type_map.values()
-        if isinstance(type_obj, GraphQLObjectType | GraphQLEnumType)
-        and has_given_directive(type_obj, Directive.INSTANCE_TAG)
-    }
+    """Remove the instanceTag source types and the now-redundant instanceTag fields on base types.
+
+    Scoped to expandable_fields so a source type still referenced by an un-expanded field survives.
+    """
+    types_to_remove = {expandable.source_type_name for expandable in expandable_fields}
 
     for base_type, tag_field_name in {
         expandable.base_type: expandable.tag_field_name for expandable in expandable_fields
@@ -387,7 +389,7 @@ def expand_instances_in_schema(
     """
     log.info("Starting instance expansion in schema")
 
-    expandable_fields = _collect_expandable_fields(schema)
+    expandable_fields = collect_expandable_fields(schema)
     log.info(f"Found {len(expandable_fields)} expandable fields")
 
     def case_for(element: ElementType, context: ContextType | None) -> CaseFormat | None:
@@ -395,7 +397,7 @@ def expand_instances_in_schema(
 
     type_case = case_for(ElementType.TYPE, ContextType.OBJECT)
     field_case = case_for(ElementType.FIELD, ContextType.OBJECT)
-    instance_tag_case = case_for(ElementType.INSTANCE_TAG, None)
+    instance_tag_case = get_instance_tag_case(naming_config)
 
     # TODO: Optimization - Cache the built type tree to avoid rebuilding it for every referencing field.
     # When multiple fields reference the same base type (e.g., Cabin.doors and Vehicle.doors both reference
@@ -408,7 +410,7 @@ def expand_instances_in_schema(
     new_types: dict[str, GraphQLObjectType] = {}
     field_metadata: dict[tuple[str, str], FieldMetadata] = {}
     for expandable in expandable_fields:
-        instances = _included_instances(expandable, instance_tag_case)
+        instances = included_instances(expandable, instance_tag_case)
         top_type, intermediate_types = _build_instance_types(
             expandable.base_type, list(expandable.instance_tag_dict), instances, expandable.leaf_nullable
         )

--- a/src/s2dm/exporters/utils/instance_tag.py
+++ b/src/s2dm/exporters/utils/instance_tag.py
@@ -175,7 +175,11 @@ def _collect_expandable_fields(schema: GraphQLSchema) -> list[_ExpandableField]:
             item_type = unwrapped.of_type if is_list else unwrapped
 
             tag_field = base_type.fields[resolved.field_name]
-            exclude = get_argument_content(tag_field, Directive.INSTANCE_TAG, DirectiveArgument.EXCLUDE) or []
+            field_exclude = get_argument_content(tag_field, Directive.INSTANCE_TAG, DirectiveArgument.EXCLUDE) or []
+            source_exclude = (
+                get_argument_content(resolved.source_type, Directive.INSTANCE_TAG, DirectiveArgument.EXCLUDE) or []
+            )
+            exclude = list(dict.fromkeys([*field_exclude, *source_exclude]))
 
             expandable_fields.append(
                 _ExpandableField(
@@ -188,7 +192,7 @@ def _collect_expandable_fields(schema: GraphQLSchema) -> list[_ExpandableField]:
                     leaf_nullable=not is_non_null_type(item_type),
                     is_list=is_list,
                     original_field=field,
-                    exclude=list(exclude),
+                    exclude=exclude,
                 )
             )
     return expandable_fields

--- a/src/s2dm/exporters/utils/instance_tag.py
+++ b/src/s2dm/exporters/utils/instance_tag.py
@@ -1,5 +1,5 @@
 from itertools import product
-from typing import Any, cast
+from typing import Any, NamedTuple, cast
 
 from graphql import (
     GraphQLEnumType,
@@ -13,57 +13,62 @@ from graphql import (
 )
 
 from s2dm import log
-from s2dm.constants.directive import Directive
+from s2dm.constants.directive import Directive, DirectiveArgument
 from s2dm.exporters.utils.annotated_schema import FieldMetadata, TypeMetadata
-from s2dm.exporters.utils.directive import get_field_with_applied_directive, has_given_directive
-from s2dm.exporters.utils.extraction import get_all_object_types, get_all_objects_with_directive
-from s2dm.exporters.utils.naming import apply_naming_to_instance_values, convert_name
-from s2dm.exporters.utils.naming_config import ContextType, ElementType, NamingConventionConfig, get_case_for_element
+from s2dm.exporters.utils.directive import (
+    get_argument_content,
+    has_given_directive,
+)
+from s2dm.exporters.utils.extraction import get_all_object_types
+from s2dm.exporters.utils.naming import convert_name
+from s2dm.exporters.utils.naming_config import (
+    CaseFormat,
+    ContextType,
+    ElementType,
+    NamingConventionConfig,
+    get_case_for_element,
+)
+
+InstanceTagSource = GraphQLObjectType | GraphQLEnumType
+
+class _ExpandableField(NamedTuple):
+    """Everything discovered for one expandable field, captured before any schema mutation."""
+
+    parent_type: GraphQLObjectType
+    field_name: str
+    base_type: GraphQLObjectType
+    tag_field_name: str
+    source_type_name: str
+    instance_tag_dict: dict[str, list[str]]
+    leaf_nullable: bool
+    is_list: bool
+    original_field: GraphQLField
+    exclude: list[str]
+
+class _ResolvedInstanceTag(NamedTuple):
+    """The valid @instanceTag field of an object type, resolved in a single pass."""
+
+    field_name: str
+    source_type: InstanceTagSource
 
 
 def is_instance_tag_field(field: GraphQLField) -> bool:
     return has_given_directive(field, Directive.INSTANCE_TAG)
 
 
-def get_all_expanded_instance_tags(
-    schema: GraphQLSchema,
-    naming_config: NamingConventionConfig | None = None,
-) -> dict[GraphQLObjectType, list[str]]:
-    all_expanded_instance_tags: dict[GraphQLObjectType, list[str]] = {}
-    for object in get_all_objects_with_directive(get_all_object_types(schema), Directive.INSTANCE_TAG):
-        all_expanded_instance_tags[object] = expand_instance_tag(object, naming_config)
+def get_instance_tag_type(field: GraphQLField, schema: GraphQLSchema) -> InstanceTagSource | None:
+    if not is_instance_tag_field(field):
+        return None
 
-    log.debug(f"All expanded tags in the spec: {all_expanded_instance_tags}")
+    named_type = get_named_type(field.type)
+    output_type = schema.get_type(named_type.name)
+    if not isinstance(output_type, GraphQLObjectType | GraphQLEnumType):
+        return None
 
-    return all_expanded_instance_tags
+    if not has_given_directive(output_type, Directive.INSTANCE_TAG):
+        return None
 
-
-def expand_instance_tag(object: GraphQLObjectType, naming_config: NamingConventionConfig | None = None) -> list[str]:
-    log.debug(f"Expanding instanceTag for object: {object.name}")
-    expanded_tags = []
-    if not has_given_directive(object, Directive.INSTANCE_TAG):
-        raise ValueError(f"Object '{object.name}' does not have an instance tag directive.")
-    else:
-        tags_per_enum_field = []
-        for field_name, field in object.fields.items():
-            field_type = field.type
-            if isinstance(field.type, GraphQLNonNull):
-                field_type = get_named_type(field.type)
-            if not isinstance(field_type, GraphQLEnumType):
-                # TODO: Move this check to a validation function for the @instanceTag directive
-                raise TypeError(f"Field '{field_name}' in object '{object.name}' is not an enum.")
-
-            enum_values = apply_naming_to_instance_values(list(field_type.values.keys()), naming_config)
-            tags_per_enum_field.append(enum_values)
-        log.debug(f"Tags per field: {tags_per_enum_field}")
-
-        # Combine tags from different enum fields
-        for combination in product(*tags_per_enum_field):
-            expanded_tags.append(".".join(combination))  # <-- Character separator can be changed HERE
-
-        log.debug(f"Expanded tags: {expanded_tags}")
-
-        return expanded_tags
+    return output_type
 
 
 def is_valid_instance_tag_field(field: GraphQLField, schema: GraphQLSchema) -> bool:
@@ -79,65 +84,47 @@ def is_valid_instance_tag_field(field: GraphQLField, schema: GraphQLSchema) -> b
     Returns:
         bool: True if the field's output type is a valid instanceTag, False otherwise.
     """
-    if not is_instance_tag_field(field):
-        return False
-
-    output_type = schema.get_type(get_named_type(field.type).name)
-    return isinstance(output_type, GraphQLObjectType) and has_given_directive(output_type, Directive.INSTANCE_TAG)
+    return get_instance_tag_type(field, schema) is not None
 
 
-def has_valid_instance_tag_field(object_type: GraphQLObjectType, schema: GraphQLSchema) -> bool:
+def _resolve_instance_tag(object_type: GraphQLObjectType, schema: GraphQLSchema) -> _ResolvedInstanceTag | None:
     """
-    Check if a given object type has a valid instanceTag field.
+    Resolve the single valid @instanceTag field of an object type.
 
-    Args:
-        object_type (GraphQLObjectType): The object type to check.
-        schema (GraphQLSchema): The GraphQL schema to validate against.
-
-    Returns:
-        bool: True if the object type has a valid instanceTag field, False otherwise.
-    """
-    return get_instance_tag_field_name(object_type, schema) is not None
-
-
-def get_instance_tag_field_name(object_type: GraphQLObjectType, schema: GraphQLSchema) -> str | None:
-    """
-    Get the name of the field annotated with a valid @instanceTag directive.
+    This is the shared lookup behind the public instanceTag helpers: it locates the valid
+    instanceTag field (if any) and the type it references, so callers stop re-walking the fields.
 
     Args:
         object_type (GraphQLObjectType): The object type to inspect.
         schema (GraphQLSchema): The GraphQL schema to validate against.
 
     Returns:
-        str | None: The name of the valid instanceTag field if found, None otherwise.
+        _ResolvedInstanceTag | None: The resolved instanceTag, or None if the object has none.
     """
-    instance_tag_fields = get_field_with_applied_directive(object_type, Directive.INSTANCE_TAG)
-    for field_name, field in instance_tag_fields.items():
-        if is_valid_instance_tag_field(field, schema):
-            return field_name
+    for field_name, field in object_type.fields.items():
+        source_type = get_instance_tag_type(field, schema)
+        if source_type is not None:
+            return _ResolvedInstanceTag(field_name, source_type)
     return None
 
 
-def get_instance_tag_object(object_type: GraphQLObjectType, schema: GraphQLSchema) -> GraphQLObjectType | None:
+def _tag_dimensions_from_source(tag_field_name: str, source_type: InstanceTagSource) -> dict[str, list[str]]:
     """
-    Get the valid instance tag object type used in a valid instance tag field.
+    Return the instanceTag dimensions of a source type as an ordered mapping.
+
+    Both object- and enum-backed sources are normalized to one ordered mapping of dimension name to
+    its enum values, so type construction and name expansion share a single representation.
 
     Args:
-        object_type (GraphQLObjectType): The object type to check.
-        schema (GraphQLSchema): The GraphQL schema to validate against.
+        tag_field_name (str): The name of the field that references the source type.
+        source_type (InstanceTagSource): The resolved instanceTag source type.
 
     Returns:
-        GraphQLObjectType | None: The valid instance tag object type if found, None otherwise.
+        dict[str, list[str]]: Ordered mapping of dimension name to enum values.
     """
-    field_name = get_instance_tag_field_name(object_type, schema)
-    if field_name is None:
-        return None
-
-    field = object_type.fields[field_name]
-    instance_tag_type = schema.get_type(get_named_type(field.type).name)
-    if isinstance(instance_tag_type, GraphQLObjectType):
-        return instance_tag_type
-    return None
+    if isinstance(source_type, GraphQLObjectType):
+        return get_instance_tag_dict(source_type)
+    return {tag_field_name: list(source_type.values.keys())}
 
 
 def get_instance_tag_dict(
@@ -167,91 +154,213 @@ def get_instance_tag_dict(
     return instance_tag_dict
 
 
-def is_expandable_field(field: GraphQLField, schema: GraphQLSchema) -> bool:
-    """
-    Check if a field is expandable (has a base type that has instanceTag).
-
-    Args:
-        field: The GraphQL field to check
-        schema: The GraphQL schema to validate against
-
-    Returns:
-        True if the field is expandable, False otherwise
-    """
-    base_type = get_named_type(field.type)
-    if isinstance(base_type, GraphQLObjectType):
-        return has_valid_instance_tag_field(base_type, schema)
-
-    return False
-
-
-def _collect_expandable_fields(
-    schema: GraphQLSchema,
-) -> list[tuple[GraphQLObjectType, str]]:
-    """
-    Collect all fields in the schema that need instance expansion.
-
-    Args:
-        schema: The GraphQL schema to scan
-
-    Returns:
-        List of tuples: (parent_type, field_name)
-    """
+def _collect_expandable_fields(schema: GraphQLSchema) -> list[_ExpandableField]:
+    """Find every field whose base type carries a valid instanceTag, without touching the schema."""
     expandable_fields = []
-    all_object_types = get_all_object_types(schema)
+    for parent_type in get_all_object_types(schema):
+        for field_name, field in parent_type.fields.items():
+            base_type = get_named_type(field.type)
+            if not isinstance(base_type, GraphQLObjectType):
+                continue
+            resolved = _resolve_instance_tag(base_type, schema)
+            if resolved is None:
+                continue
 
-    for object_type in all_object_types:
-        for field_name, field in object_type.fields.items():
-            if is_expandable_field(field, schema):
-                expandable_fields.append((object_type, field_name))
+            unwrapped = field.type
+            if is_non_null_type(unwrapped):
+                unwrapped = unwrapped.of_type
+            is_list = is_list_type(unwrapped)
+            item_type = unwrapped.of_type if is_list else unwrapped
 
+            tag_field = base_type.fields[resolved.field_name]
+            exclude = get_argument_content(tag_field, Directive.INSTANCE_TAG, DirectiveArgument.EXCLUDE) or []
+
+            expandable_fields.append(
+                _ExpandableField(
+                    parent_type=parent_type,
+                    field_name=field_name,
+                    base_type=base_type,
+                    tag_field_name=resolved.field_name,
+                    source_type_name=resolved.source_type.name,
+                    instance_tag_dict=_tag_dimensions_from_source(resolved.field_name, resolved.source_type),
+                    leaf_nullable=not is_non_null_type(item_type),
+                    is_list=is_list,
+                    original_field=field,
+                    exclude=list(exclude),
+                )
+            )
     return expandable_fields
 
 
-def _create_intermediate_types(
-    base_type: GraphQLObjectType,
-    instance_tag_dict: dict[str, list[str]],
-    list_item_nullable: bool,
-) -> list[GraphQLObjectType]:
+def _included_instances(
+    expandable: _ExpandableField,
+    instance_tag_case: CaseFormat | None,
+) -> list[tuple[str, ...]]:
     """
-    Create intermediate GraphQL types for instance expansion.
+    Return the instances the field expands into after applying its exclude list.
+
+    Exclude entries are authored against the schema's literal enum values; when a naming
+    convention has renamed those values, each dotted segment is cased the same way before
+    matching. An entry that matches no instance is a configuration error.
 
     Args:
-        base_type: The base type (e.g., Door)
-        instance_tag_dict: Dict of enum field names to their values
-        list_item_nullable: Whether the original list items were nullable
+        expandable: The field being expanded, carrying its dimensions and exclude list.
+        instance_tag_case: The case applied to instanceTag values, or None when unconfigured.
 
     Returns:
-        List of intermediate types, with first intermediate type at the end
+        list[tuple[str, ...]]: The included instances in cartesian-product order.
+
+    Raises:
+        ValueError: If any exclude entry matches no instance.
     """
-    enum_fields = list(instance_tag_dict.keys())
-    intermediate_types: list[GraphQLObjectType] = []
+    instances = list(product(*expandable.instance_tag_dict.values()))
+    if not expandable.exclude:
+        return instances
 
-    for i in range(len(enum_fields) - 1, -1, -1):
-        enum_field_name = enum_fields[i]
-        enum_values = instance_tag_dict[enum_field_name]
+    def normalize(entry: str) -> tuple[str, ...]:
+        segments = entry.split(".")
+        if instance_tag_case:
+            segments = [convert_name(segment, instance_tag_case) for segment in segments]
+        return tuple(segments)
 
-        intermediate_type_name = f"{base_type.name}_{enum_field_name.capitalize()}"
+    unmatched = {normalize(entry): entry for entry in expandable.exclude}
+    included: list[tuple[str, ...]] = []
+    for instance in instances:
+        if unmatched.pop(instance, None) is None:
+            included.append(instance)
 
-        is_leaf_level = i == len(enum_fields) - 1
-        target_type = base_type if is_leaf_level else intermediate_types[-1]
-
-        intermediate_fields = {}
-        for enum_value in enum_values:
-            field_type: GraphQLObjectType | GraphQLNonNull[GraphQLObjectType] = (
-                target_type if is_leaf_level and list_item_nullable else GraphQLNonNull(target_type)
-            )
-            intermediate_fields[enum_value] = GraphQLField(field_type)
-
-        intermediate_type = GraphQLObjectType(
-            name=intermediate_type_name,
-            fields=intermediate_fields,
+    if unmatched:
+        raise ValueError(
+            f"@instanceTag exclude entries {sorted(unmatched.values())} on "
+            f"'{expandable.parent_type.name}.{expandable.field_name}' match no instance; "
+            f"supported instances are {sorted('.'.join(instance) for instance in instances)}"
         )
 
-        intermediate_types.append(intermediate_type)
-        log.debug(f"Created intermediate type '{intermediate_type_name}' with fields: {list(enum_values)}")
+    return included
 
-    return intermediate_types
+
+def _build_instance_types(
+    base_type: GraphQLObjectType,
+    dimensions: list[str],
+    instances: list[tuple[str, ...]],
+    leaf_nullable: bool,
+) -> tuple[GraphQLObjectType, list[GraphQLObjectType]]:
+    """
+    Build the intermediate type tree spanning the given instances.
+
+    The instances form a trie keyed by dimension: sibling branches with an identical set of
+    remaining instances share one type, while branches left asymmetric by an exclusion split
+    into their own types named after the path that reaches them.
+
+    Example:
+        dimensions=["a", "b"] over A1/A2 x B1/B2, with leaves pointing at the base type Base.
+
+        Nothing excluded - both A branches expand identically, so the b level is built once and shared:
+            Base_A -> { A1: Base_B, A2: Base_B }
+            Base_B -> { B1: Base, B2: Base }
+
+        Excluding A1.B1 - the A branches now differ, so each gets its own b type:
+            Base_A    -> { A1: Base_A1_B, A2: Base_A2_B }
+            Base_A1_B -> { B2: Base }
+            Base_A2_B -> { B1: Base, B2: Base }
+
+    Args:
+        base_type: The base type the leaves point at (e.g., Base).
+        dimensions: The instanceTag dimension names, outermost first.
+        instances: The included instances, each aligned with ``dimensions``.
+        leaf_nullable: Whether the field's leaf type (list item, or the base type for a non-list field) was nullable.
+
+    Returns:
+        tuple: The top intermediate type and every type created while building the tree.
+    """
+    created: list[GraphQLObjectType] = []
+
+    def build(level: int, remaining: list[tuple[str, ...]], name_prefix: str) -> GraphQLObjectType:
+        dimension = dimensions[level]
+        groups: dict[str, list[tuple[str, ...]]] = {}
+        for suffix in remaining:
+            groups.setdefault(suffix[0], []).append(suffix[1:])
+
+        fields: dict[str, GraphQLField] = {}
+        if level == len(dimensions) - 1:
+            leaf_type = base_type if leaf_nullable else GraphQLNonNull(base_type)
+            fields = {value: GraphQLField(leaf_type) for value in groups}
+        else:
+            siblings_share_subtree = len({frozenset(subsuffixes) for subsuffixes in groups.values()}) == 1
+            if siblings_share_subtree:
+                shared = build(level + 1, next(iter(groups.values())), name_prefix)
+                fields = {value: GraphQLField(GraphQLNonNull(shared)) for value in groups}
+            else:
+                for value, subsuffixes in groups.items():
+                    child = build(level + 1, subsuffixes, f"{name_prefix}{value}_")
+                    fields[value] = GraphQLField(GraphQLNonNull(child))
+
+        instance_type = GraphQLObjectType(
+            name=f"{base_type.name}_{name_prefix}{dimension.capitalize()}", fields=fields
+        )
+        created.append(instance_type)
+        log.debug(f"Created intermediate type '{instance_type.name}' with fields: {list(fields)}")
+        return instance_type
+
+    top_type = build(0, instances, "")
+    return top_type, created
+
+
+def _apply_expansion(
+    expandable: _ExpandableField,
+    top_type: GraphQLObjectType,
+    intermediate_types: list[GraphQLObjectType],
+    instances: list[tuple[str, ...]],
+    type_case: CaseFormat | None,
+    field_case: CaseFormat | None,
+    new_types: dict[str, GraphQLObjectType],
+    field_metadata: dict[tuple[str, str], FieldMetadata],
+) -> None:
+    """Apply naming to the built types and replace the parent field with its expanded form."""
+    for intermediate_type in intermediate_types:
+        if type_case:
+            intermediate_type.name = convert_name(intermediate_type.name, type_case)
+        new_types[intermediate_type.name] = intermediate_type
+
+    base_name = expandable.base_type.name if expandable.is_list else expandable.field_name
+    new_field_name = convert_name(base_name, field_case) if field_case else base_name
+
+    field_metadata[(expandable.parent_type.name, new_field_name)] = FieldMetadata(
+        resolved_names=[f"{new_field_name}.{'.'.join(instance)}" for instance in instances],
+        resolved_type=expandable.base_type.name,
+        is_expanded=True,
+        original_field=expandable.original_field,
+        instances=list(expandable.instance_tag_dict.values()),
+    )
+
+    new_field = GraphQLField(type_=GraphQLNonNull(top_type), description=expandable.original_field.description)
+    del expandable.parent_type.fields[expandable.field_name]
+    expandable.parent_type.fields[new_field_name] = new_field
+    log.debug(
+        f"Replaced field '{expandable.field_name}' with '{new_field_name}' in type '{expandable.parent_type.name}'"
+    )
+
+
+def _cleanup_instance_tag_artifacts(schema: GraphQLSchema, expandable_fields: list[_ExpandableField]) -> None:
+    """Remove the instanceTag source types and the now-redundant instanceTag fields on base types."""
+    types_to_remove = {
+        type_obj.name
+        for type_obj in schema.type_map.values()
+        if isinstance(type_obj, GraphQLObjectType | GraphQLEnumType)
+        and has_given_directive(type_obj, Directive.INSTANCE_TAG)
+    }
+
+    for base_type, tag_field_name in {
+        expandable.base_type: expandable.tag_field_name for expandable in expandable_fields
+    }.items():
+        if tag_field_name in base_type.fields:
+            del base_type.fields[tag_field_name]
+            log.debug(f"Removed '{tag_field_name}' instanceTag field from type '{base_type.name}'")
+
+    for type_name in types_to_remove:
+        if type_name in schema.type_map:
+            del schema.type_map[type_name]
+            log.debug(f"Removed type '{type_name}' with @instanceTag directive from schema")
 
 
 def expand_instances_in_schema(
@@ -277,97 +386,36 @@ def expand_instances_in_schema(
     expandable_fields = _collect_expandable_fields(schema)
     log.info(f"Found {len(expandable_fields)} expandable fields")
 
-    base_types_to_clean: set[GraphQLObjectType] = set()
-    instance_tag_types_to_remove: set[str] = set()
+    def case_for(element: ElementType, context: ContextType | None) -> CaseFormat | None:
+        return get_case_for_element(element, context, naming_config) if naming_config else None
+
+    type_case = case_for(ElementType.TYPE, ContextType.OBJECT)
+    field_case = case_for(ElementType.FIELD, ContextType.OBJECT)
+    instance_tag_case = case_for(ElementType.INSTANCE_TAG, None)
+
+    # TODO: Optimization - Cache the built type tree to avoid rebuilding it for every referencing field.
+    # When multiple fields reference the same base type (e.g., Cabin.doors and Vehicle.doors both reference
+    # [Door]), we build the Door_* intermediate types once per field. The instances are base-type determined
+    # (the exclude list lives on the base type's instanceTag field), so the trees are identical and the
+    # later-built one currently just overwrites the earlier in new_types.
+    # A cache cannot key on base_type.name alone: leaf_nullable is per-field (e.g. [Door] vs [Door!]), so two
+    # fields can need different leaf types under the same intermediate names. Key on (base_type.name,
+    # leaf_nullable) and disambiguate the generated names accordingly before reusing the built tree.
     new_types: dict[str, GraphQLObjectType] = {}
-    type_metadata: dict[str, TypeMetadata] = {}
     field_metadata: dict[tuple[str, str], FieldMetadata] = {}
-
-    # TODO: Optimization - Cache expanded types to avoid creating duplicate intermediate types
-    # When multiple fields reference the same base type (e.g., Cabin.doors and Vehicle.doors both reference [Door]),
-    # we currently create intermediate types twice. Instead, maintain a cache:
-    # expanded_types_cache: dict[str, GraphQLObjectType] = {}  # Maps base_type.name -> first_intermediate_type
-    # Check cache before creating, reuse if exists, otherwise create once and cache.
-
-    for parent_type, field_name in expandable_fields:
-        original_field = parent_type.fields[field_name]
-        base_type = cast(GraphQLObjectType, get_named_type(original_field.type))
-
-        log.debug(f"Processing field '{field_name}' in type '{parent_type.name}' with base type '{base_type.name}'")
-
-        unwrapped_type = original_field.type
-        if is_non_null_type(unwrapped_type):
-            unwrapped_type = unwrapped_type.of_type
-
-        target_type = unwrapped_type.of_type if is_list_type(unwrapped_type) else unwrapped_type
-        list_item_nullable = not is_non_null_type(target_type)
-
-        instance_tag_object = cast(GraphQLObjectType, get_instance_tag_object(base_type, schema))
-        instance_tag_dict = get_instance_tag_dict(instance_tag_object)
-        instance_tag_types_to_remove.add(instance_tag_object.name)
-
-        intermediate_types = _create_intermediate_types(base_type, instance_tag_dict, list_item_nullable)
-        first_intermediate_type = intermediate_types[-1]
-
-        type_case = get_case_for_element(ElementType.TYPE, ContextType.OBJECT, naming_config) if naming_config else None
-        field_case = (
-            get_case_for_element(ElementType.FIELD, ContextType.OBJECT, naming_config) if naming_config else None
+    for expandable in expandable_fields:
+        instances = _included_instances(expandable, instance_tag_case)
+        top_type, intermediate_types = _build_instance_types(
+            expandable.base_type, list(expandable.instance_tag_dict), instances, expandable.leaf_nullable
+        )
+        _apply_expansion(
+            expandable, top_type, intermediate_types, instances, type_case, field_case, new_types, field_metadata
         )
 
-        for intermediate_type in intermediate_types:
-            type_name = convert_name(intermediate_type.name, type_case) if type_case else intermediate_type.name
-            intermediate_type.name = type_name
-            new_types[type_name] = intermediate_type
-            type_metadata[type_name] = TypeMetadata(source=None, is_intermediate_type=True)
+    _cleanup_instance_tag_artifacts(schema, expandable_fields)
+    schema.type_map.update(new_types)
 
-        base_name = base_type.name if is_list_type(unwrapped_type) else field_name
-        new_field_name = convert_name(base_name, field_case) if field_case else base_name
-
-        resolved_names = [
-            f"{new_field_name}.{'.'.join(instance_product)}"
-            for instance_product in product(*instance_tag_dict.values())
-        ]
-
-        instances = list(instance_tag_dict.values())
-
-        new_field = GraphQLField(
-            type_=GraphQLNonNull(first_intermediate_type),
-            description=original_field.description,
-        )
-
-        field_metadata[(parent_type.name, new_field_name)] = FieldMetadata(
-            resolved_names=resolved_names,
-            resolved_type=base_type.name,
-            is_expanded=True,
-            original_field=original_field,
-            instances=instances,
-        )
-
-        del parent_type.fields[field_name]
-        parent_type.fields[new_field_name] = new_field
-
-        log.debug(f"Replaced field '{field_name}' with '{new_field_name}' in type '{parent_type.name}'")
-
-        base_types_to_clean.add(base_type)
-
-    all_types_to_remove = set(instance_tag_types_to_remove)
-    all_instance_tag_types = get_all_objects_with_directive(get_all_object_types(schema), Directive.INSTANCE_TAG)
-    all_types_to_remove.update(t.name for t in all_instance_tag_types)
-
-    for base_type in base_types_to_clean:
-        tag_field_name = get_instance_tag_field_name(base_type, schema)
-        if tag_field_name is not None:
-            del base_type.fields[tag_field_name]
-            log.debug(f"Removed '{tag_field_name}' instanceTag field from type '{base_type.name}'")
-
-    for type_name in all_types_to_remove:
-        if type_name in schema.type_map:
-            del schema.type_map[type_name]
-            log.debug(f"Removed type '{type_name}' with @instanceTag directive from schema")
-
-    for type_name, new_type in new_types.items():
-        schema.type_map[type_name] = new_type
-
+    type_metadata = {name: TypeMetadata(source=None, is_intermediate_type=True) for name in new_types}
     log.info(f"Instance expansion complete. Created {len(new_types)} intermediate types")
 
     return schema, type_metadata, field_metadata

--- a/src/s2dm/exporters/utils/instance_tag.py
+++ b/src/s2dm/exporters/utils/instance_tag.py
@@ -31,6 +31,7 @@ from s2dm.exporters.utils.naming_config import (
 
 InstanceTagSource = GraphQLObjectType | GraphQLEnumType
 
+
 class _ExpandableField(NamedTuple):
     """Everything discovered for one expandable field, captured before any schema mutation."""
 
@@ -44,6 +45,7 @@ class _ExpandableField(NamedTuple):
     is_list: bool
     original_field: GraphQLField
     exclude: list[str]
+
 
 class _ResolvedInstanceTag(NamedTuple):
     """The valid @instanceTag field of an object type, resolved in a single pass."""
@@ -295,9 +297,7 @@ def _build_instance_types(
                     child = build(level + 1, subsuffixes, f"{name_prefix}{value}_")
                     fields[value] = GraphQLField(GraphQLNonNull(child))
 
-        instance_type = GraphQLObjectType(
-            name=f"{base_type.name}_{name_prefix}{dimension.capitalize()}", fields=fields
-        )
+        instance_type = GraphQLObjectType(name=f"{base_type.name}_{name_prefix}{dimension.capitalize()}", fields=fields)
         created.append(instance_type)
         log.debug(f"Created intermediate type '{instance_type.name}' with fields: {list(fields)}")
         return instance_type

--- a/src/s2dm/exporters/utils/naming.py
+++ b/src/s2dm/exporters/utils/naming.py
@@ -58,17 +58,20 @@ def convert_name(name: str, target_case: CaseFormat) -> str:
     return str(CASE_CONVERTERS[target_case](name))
 
 
-def _collect_instance_tag_enum_names(schema: GraphQLSchema) -> set[str]:
-    """Collect names of enum types used as fields of @instanceTag object types."""
+def collect_instance_tag_enum_names(schema: GraphQLSchema) -> set[str]:
+    """Collect enum type names that should use instanceTag naming rules."""
     instance_tag_enum_names: set[str] = set()
     for type_obj in schema.type_map.values():
-        if not isinstance(type_obj, GraphQLObjectType) or not has_given_directive(type_obj, Directive.INSTANCE_TAG):
+        if isinstance(type_obj, GraphQLEnumType) and has_given_directive(type_obj, Directive.INSTANCE_TAG):
+            instance_tag_enum_names.add(type_obj.name)
             continue
-        for field in type_obj.fields.values():
-            field_base_type = get_named_type(field.type)
-            field_type_obj = schema.get_type(field_base_type.name)
-            if isinstance(field_type_obj, GraphQLEnumType):
-                instance_tag_enum_names.add(field_base_type.name)
+
+        if isinstance(type_obj, GraphQLObjectType) and has_given_directive(type_obj, Directive.INSTANCE_TAG):
+            for field in type_obj.fields.values():
+                field_base_type = get_named_type(field.type)
+                field_type_obj = schema.get_type(field_base_type.name)
+                if isinstance(field_type_obj, GraphQLEnumType):
+                    instance_tag_enum_names.add(field_base_type.name)
     return instance_tag_enum_names
 
 
@@ -79,7 +82,7 @@ def apply_naming_to_schema(schema: GraphQLSchema, naming_config: NamingConventio
         schema: The GraphQL schema to modify
         naming_config: Naming convention configuration
     """
-    instance_tag_enum_names = _collect_instance_tag_enum_names(schema)
+    instance_tag_enum_names = collect_instance_tag_enum_names(schema)
 
     types_to_rename = []
     for type_name, type_obj in schema.type_map.items():

--- a/src/s2dm/exporters/utils/naming.py
+++ b/src/s2dm/exporters/utils/naming.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from typing import Any
 
 from caseconverter import camelcase, cobolcase, flatcase, kebabcase, macrocase, pascalcase, snakecase, titlecase
 from graphql import (
@@ -13,6 +12,7 @@ from graphql import (
     get_named_type,
 )
 
+from s2dm.constants.directive import Directive
 from s2dm.exporters.utils.directive import has_given_directive
 from s2dm.exporters.utils.graphql_type import is_graphql_system_type
 from s2dm.exporters.utils.naming_config import (
@@ -62,7 +62,7 @@ def _collect_instance_tag_enum_names(schema: GraphQLSchema) -> set[str]:
     """Collect names of enum types used as fields of @instanceTag object types."""
     instance_tag_enum_names: set[str] = set()
     for type_obj in schema.type_map.values():
-        if not isinstance(type_obj, GraphQLObjectType) or not has_given_directive(type_obj, "instanceTag"):
+        if not isinstance(type_obj, GraphQLObjectType) or not has_given_directive(type_obj, Directive.INSTANCE_TAG):
             continue
         for field in type_obj.fields.values():
             field_base_type = get_named_type(field.type)
@@ -108,33 +108,6 @@ def apply_naming_to_schema(schema: GraphQLSchema, naming_config: NamingConventio
         schema.type_map[new_name] = type_obj
 
 
-def is_instance_tag_field(field_name: str, field: Any, schema: GraphQLSchema) -> bool:
-    """Check if a field is an instanceTag field that should not be renamed.
-
-    Args:
-        field_name: Name of the field to check
-        field: The GraphQL field object
-        schema: The GraphQL schema containing the field's type
-
-    Returns:
-        True if this is an instanceTag field that should preserve its name
-    """
-    if field_name != "instanceTag":
-        return False
-
-    field_type = get_named_type(field.type)
-    target_type = schema.get_type(field_type.name)
-
-    if not isinstance(target_type, GraphQLObjectType):
-        return False
-
-    if target_type.ast_node and target_type.ast_node.directives:
-        for directive in target_type.ast_node.directives:
-            if directive.name.value == "instanceTag":
-                return True
-    return False
-
-
 def convert_field_names(
     type_obj: GraphQLObjectType | GraphQLInterfaceType | GraphQLInputObjectType,
     naming_config: NamingConventionConfig,
@@ -155,11 +128,8 @@ def convert_field_names(
     if target_case:
         new_fields = {}
         for old_name, field in type_obj.fields.items():
-            if is_instance_tag_field(old_name, field, schema):
-                new_fields[old_name] = field
-            else:
-                new_name = convert_name(old_name, target_case)
-                new_fields[new_name] = field
+            new_name = convert_name(old_name, target_case)
+            new_fields[new_name] = field
 
         type_obj.fields.clear()
         type_obj.fields.update(new_fields)

--- a/src/s2dm/exporters/utils/schema_loader.py
+++ b/src/s2dm/exporters/utils/schema_loader.py
@@ -39,6 +39,7 @@ from graphql.language.ast import (
 )
 
 from s2dm import log
+from s2dm.constants.directive import Directive, DirectiveArgument
 from s2dm.exporters.utils.annotated_schema import (
     AnnotatedSchema,
     FieldMetadata,
@@ -48,13 +49,16 @@ from s2dm.exporters.utils.directive import (
     GRAPHQL_TYPE_DEFINITION_PATTERN,
     add_directives_to_schema,
     build_directive_map,
+    get_objects_with_multiple_fields_with_directive,
     get_type_directive_location,
     has_given_directive,
 )
+from s2dm.exporters.utils.extraction import get_all_object_types
 from s2dm.exporters.utils.graphql_type import is_introspection_or_root_type, is_introspection_type
-from s2dm.exporters.utils.instance_tag import expand_instances_in_schema
+from s2dm.exporters.utils.instance_tag import expand_instances_in_schema, is_valid_instance_tag_field
 from s2dm.exporters.utils.naming import apply_naming_to_schema, convert_name, load_naming_config
 from s2dm.exporters.utils.naming_config import ContextType, ElementType, NamingConventionConfig, get_case_for_element
+from s2dm.exporters.utils.violations import ConstraintCode, ConstraintViolation
 from s2dm.utils.download import download_url_to_temp
 
 SourceMapValueResolver = Callable[[Path, str], str]
@@ -288,8 +292,8 @@ def print_schema_with_directives_preserved(schema: GraphQLSchema, source_map: di
     """
     directive_map = build_directive_map(schema)
 
-    reference_directive = schema.get_directive("reference")
-    if source_map and reference_directive is not None and "source" in reference_directive.args:
+    reference_directive = schema.get_directive(Directive.REFERENCE)
+    if source_map and reference_directive is not None and DirectiveArgument.SOURCE in reference_directive.args:
         log.info(f"Adding @reference directive to the the following locations only: {reference_directive.locations}")
 
         for type_name, source_filename in source_map.items():
@@ -330,7 +334,7 @@ def compose_schemas_to_string(
     )
     schema_errors = check_correct_schema(graphql_schema)
     if schema_errors:
-        raise ValueError("Schema validation failed:\n" + "\n".join(schema_errors))
+        raise ValueError("Schema validation failed:\n" + "\n".join(violation.message for violation in schema_errors))
 
     query_document = None
     if selection_query:
@@ -486,42 +490,45 @@ def check_enum_defaults(schema: GraphQLSchema) -> list[str]:
 
 
 @overload
-def check_correct_schema(schema: GraphQLSchema) -> list[str]: ...
+def check_correct_schema(schema: GraphQLSchema) -> list[ConstraintViolation]: ...
 
 
 @overload
-def check_correct_schema(schema: Path) -> list[str]: ...
+def check_correct_schema(schema: Path) -> list[ConstraintViolation]: ...
 
 
-def check_correct_schema(schema: GraphQLSchema | Path) -> list[str]:
-    """Assert that the schema conforms to GraphQL specification and has valid enum defaults.
+def check_correct_schema(schema: GraphQLSchema | Path) -> list[ConstraintViolation]:
+    """Validate that the schema conforms to the GraphQL spec, has valid enum defaults, and valid instance tags.
 
     Args:
         schema: The GraphQL schema or schema file path to validate
 
     Returns:
-        list[str]: List of error messages if any validation errors are found
-
-    Exits:
-        Calls sys.exit(1) if the schema has validation errors
+        list[ConstraintViolation]: Structured violations found, empty if the schema is valid.
     """
     if isinstance(schema, Path):
         schema = build_schema(schema.read_text(encoding="utf-8"))
 
     spec_errors = validate_schema(schema)
     enum_errors = check_enum_defaults(schema)
+    objects_with_multiple_instance_tags = get_objects_with_multiple_fields_with_directive(
+        get_all_object_types(schema), Directive.INSTANCE_TAG
+    )
 
-    all_errors: list[str] = []
+    violations: list[ConstraintViolation] = []
 
-    if spec_errors:
-        for spec_error in spec_errors:
-            all_errors.append(f"  - {spec_error.message}")
+    for spec_error in spec_errors:
+        violations.append(ConstraintViolation(ConstraintCode.SCHEMA_SPEC, spec_error.message))
 
-    if enum_errors:
-        for enum_error in enum_errors:
-            all_errors.append(f"  - {enum_error}")
+    for enum_error in enum_errors:
+        violations.append(ConstraintViolation(ConstraintCode.ENUM_DEFAULT, str(enum_error)))
 
-    return all_errors
+    for obj_name, field_names in objects_with_multiple_instance_tags.items():
+        joined = ", ".join(field_names)
+        message = f"[instanceTag] {obj_name} must have at most one @instanceTag field (found: {joined})"
+        violations.append(ConstraintViolation(ConstraintCode.INSTANCE_TAG_MULTIPLE_FIELDS, message))
+
+    return violations
 
 
 def ensure_query(schema: GraphQLSchema) -> GraphQLSchema:
@@ -587,7 +594,7 @@ def get_referenced_types(
 
         if is_object_type(type_def):
             object_type = cast(GraphQLObjectType, type_def)
-            if not has_given_directive(object_type, "instanceTag") or include_instance_tag_fields:
+            if not has_given_directive(object_type, Directive.INSTANCE_TAG) or include_instance_tag_fields:
                 visit_object_type(object_type)
         elif is_interface_type(type_def):
             visit_interface_type(cast(GraphQLInterfaceType, type_def))
@@ -750,11 +757,20 @@ def prune_schema_using_query_selection(
 
         composite_type = cast(GraphQLObjectType | GraphQLInterfaceType, graphql_type)
 
-        if include_instance_tag_fields and "instanceTag" in composite_type.fields:
-            fields_to_keep[type_name].add("instanceTag")
-            instance_tag_field = composite_type.fields["instanceTag"]
-            instance_tag_type = get_named_type(instance_tag_field.type)
-            keep_type(instance_tag_type.name)
+        if include_instance_tag_fields:
+            instance_tag_field_name = next(
+                (
+                    field_name
+                    for field_name, field in composite_type.fields.items()
+                    if is_valid_instance_tag_field(field, schema)
+                ),
+                None,
+            )
+            if instance_tag_field_name is not None:
+                fields_to_keep[type_name].add(instance_tag_field_name)
+                instance_tag_field = composite_type.fields[instance_tag_field_name]
+                instance_tag_type = get_named_type(instance_tag_field.type)
+                keep_type(instance_tag_type.name)
 
         for selection in selection_set.selections:
             if isinstance(selection, InlineFragmentNode) and selection.selection_set is not None:

--- a/src/s2dm/exporters/utils/schema_loader.py
+++ b/src/s2dm/exporters/utils/schema_loader.py
@@ -17,7 +17,6 @@ from graphql import (
     GraphQLString,
     GraphQLType,
     GraphQLUnionType,
-    Undefined,
     build_schema,
     get_named_type,
     is_input_object_type,
@@ -26,12 +25,9 @@ from graphql import (
     is_union_type,
     parse,
     print_schema,
-    validate_schema,
 )
 from graphql import validate as graphql_validate
 from graphql.language.ast import (
-    DirectiveNode,
-    EnumValueNode,
     FieldNode,
     InlineFragmentNode,
     OperationDefinitionNode,
@@ -49,7 +45,6 @@ from s2dm.exporters.utils.directive import (
     GRAPHQL_TYPE_DEFINITION_PATTERN,
     add_directives_to_schema,
     build_directive_map,
-    get_objects_with_multiple_fields_with_directive,
     get_type_directive_location,
     has_given_directive,
 )
@@ -58,7 +53,8 @@ from s2dm.exporters.utils.graphql_type import is_introspection_or_root_type, is_
 from s2dm.exporters.utils.instance_tag import expand_instances_in_schema, is_valid_instance_tag_field
 from s2dm.exporters.utils.naming import apply_naming_to_schema, convert_name, load_naming_config
 from s2dm.exporters.utils.naming_config import ContextType, ElementType, NamingConventionConfig, get_case_for_element
-from s2dm.exporters.utils.violations import ConstraintCode, ConstraintViolation
+from s2dm.exporters.utils.violations import ConstraintViolation, Severity
+from s2dm.tools.constraint_checker import ConstraintChecker
 from s2dm.utils.download import download_url_to_temp
 
 SourceMapValueResolver = Callable[[Path, str], str]
@@ -373,122 +369,6 @@ def create_tempfile_to_composed_schema(graphql_schema_paths: list[Path]) -> Path
     return Path(temp_path)
 
 
-def _check_directive_usage_on_node(schema: GraphQLSchema, directive_node: DirectiveNode, context: str) -> list[str]:
-    """Check enum values in directive usage on a specific node."""
-    errors: list[str] = []
-
-    directive_def = schema.get_directive(directive_node.name.value)
-    if not directive_def:
-        return errors
-
-    for arg_node in directive_node.arguments:
-        arg_name = arg_node.name.value
-        arg_def = directive_def.args[arg_name]
-        named_type = get_named_type(arg_def.type)
-
-        if not isinstance(named_type, GraphQLEnumType):
-            continue
-
-        if not isinstance(arg_node.value, EnumValueNode):
-            continue
-
-        enum_value = arg_node.value.value
-        if enum_value not in named_type.values:
-            errors.append(
-                f"{context} uses directive '@{directive_node.name.value}({arg_name})' "
-                f"with invalid enum value '{enum_value}'. Valid values are: {list(named_type.values.keys())}"
-            )
-
-    return errors
-
-
-def check_enum_defaults(schema: GraphQLSchema) -> list[str]:
-    """Check that all enum default values exist in their enum definitions.
-
-    Args:
-        schema: The GraphQL schema to validate
-
-    Returns:
-        List of error messages for invalid enum defaults
-    """
-    errors = []
-
-    for type_name, type_obj in schema.type_map.items():
-        # Validate directive usage on types
-        if type_obj.ast_node and type_obj.ast_node.directives:
-            for directive_node in type_obj.ast_node.directives:
-                errors.extend(_check_directive_usage_on_node(schema, directive_node, f"Type '{type_name}'"))
-
-        # Validate input object field defaults
-        if isinstance(type_obj, GraphQLInputObjectType):
-            for field_name, field in type_obj.fields.items():
-                named_type = get_named_type(field.type)
-                if not isinstance(named_type, GraphQLEnumType):
-                    continue
-
-                has_default_in_ast = field.ast_node and field.ast_node.default_value is not None
-                if not (has_default_in_ast and field.default_value is Undefined):
-                    continue
-
-                invalid_value = field.ast_node.default_value.value
-                errors.append(
-                    f"Input type '{type_name}.{field_name}' has invalid enum default value '{invalid_value}'. "
-                    f"Valid values are: {list(named_type.values.keys())}"
-                )
-
-        # Validate field argument defaults and directive usage on fields
-        if isinstance(type_obj, GraphQLObjectType | GraphQLInterfaceType | GraphQLInputObjectType):
-            for field_name, field in type_obj.fields.items():
-                # Validate directive usage on fields
-                if field.ast_node and field.ast_node.directives:
-                    for directive_node in field.ast_node.directives:
-                        errors.extend(
-                            _check_directive_usage_on_node(schema, directive_node, f"Field '{type_name}.{field_name}'")
-                        )
-
-                # Validate field argument defaults
-                if isinstance(type_obj, GraphQLObjectType | GraphQLInterfaceType):
-                    for arg_name, arg in field.args.items():
-                        named_type = get_named_type(arg.type)
-                        if not isinstance(named_type, GraphQLEnumType):
-                            continue
-
-                        has_default_in_ast = arg.ast_node and arg.ast_node.default_value is not None
-                        if not (has_default_in_ast and arg.default_value is Undefined):
-                            continue
-
-                        invalid_value = arg.ast_node.default_value.value
-                        errors.append(
-                            f"Field argument '{type_name}.{field_name}({arg_name})' "
-                            f"has invalid enum default value '{invalid_value}'. "
-                            f"Valid values are: {list(named_type.values.keys())}"
-                        )
-
-    # Validate directive definition defaults
-    for directive in schema.directives:
-        for arg_name, arg in directive.args.items():
-            named_type = get_named_type(arg.type)
-            if not isinstance(named_type, GraphQLEnumType):
-                continue
-
-            if not arg.ast_node or not arg.ast_node.default_value:
-                continue
-
-            if arg.default_value is not Undefined:
-                continue
-
-            if not isinstance(arg.ast_node.default_value, EnumValueNode):
-                continue
-
-            invalid_value = arg.ast_node.default_value.value
-            errors.append(
-                f"Directive definition '@{directive.name}({arg_name})' "
-                f"has invalid enum default value '{invalid_value}'. Valid values are: {list(named_type.values.keys())}"
-            )
-
-    return errors
-
-
 @overload
 def check_correct_schema(schema: GraphQLSchema) -> list[ConstraintViolation]: ...
 
@@ -498,37 +378,24 @@ def check_correct_schema(schema: Path) -> list[ConstraintViolation]: ...
 
 
 def check_correct_schema(schema: GraphQLSchema | Path) -> list[ConstraintViolation]:
-    """Validate that the schema conforms to the GraphQL spec, has valid enum defaults, and valid instance tags.
+    """Validate the schema spec, enum defaults, and directive constraints, logging warnings and returning only errors.
 
     Args:
         schema: The GraphQL schema or schema file path to validate
 
     Returns:
-        list[ConstraintViolation]: Structured violations found, empty if the schema is valid.
+        list[ConstraintViolation]: Error-severity violations found, empty if the schema is valid.
     """
     if isinstance(schema, Path):
         schema = build_schema(schema.read_text(encoding="utf-8"))
 
-    spec_errors = validate_schema(schema)
-    enum_errors = check_enum_defaults(schema)
-    objects_with_multiple_instance_tags = get_objects_with_multiple_fields_with_directive(
-        get_all_object_types(schema), Directive.INSTANCE_TAG
-    )
+    objects = get_all_object_types(schema)
+    violations = ConstraintChecker(schema).run(objects)
+    for violation in violations:
+        if violation.severity == Severity.WARNING:
+            log.warning(violation.message)
 
-    violations: list[ConstraintViolation] = []
-
-    for spec_error in spec_errors:
-        violations.append(ConstraintViolation(ConstraintCode.SCHEMA_SPEC, spec_error.message))
-
-    for enum_error in enum_errors:
-        violations.append(ConstraintViolation(ConstraintCode.ENUM_DEFAULT, str(enum_error)))
-
-    for obj_name, field_names in objects_with_multiple_instance_tags.items():
-        joined = ", ".join(field_names)
-        message = f"[instanceTag] {obj_name} must have at most one @instanceTag field (found: {joined})"
-        violations.append(ConstraintViolation(ConstraintCode.INSTANCE_TAG_MULTIPLE_FIELDS, message))
-
-    return violations
+    return [violation for violation in violations if violation.severity == Severity.ERROR]
 
 
 def ensure_query(schema: GraphQLSchema) -> GraphQLSchema:

--- a/src/s2dm/exporters/utils/violations.py
+++ b/src/s2dm/exporters/utils/violations.py
@@ -1,0 +1,24 @@
+"""Structured schema-validation violations shared across the constraint checker and schema loader."""
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class ConstraintCode(str, Enum):
+    SCHEMA_SPEC = "schema.spec"
+    ENUM_DEFAULT = "schema.enum_default"
+    INSTANCE_TAG_INVALID_REFERENCE = "instanceTag.invalid_reference"
+    INSTANCE_TAG_MULTIPLE_FIELDS = "instanceTag.multiple_fields"
+    INSTANCE_TAG_NON_ENUM_FIELD = "instanceTag.non_enum_field"
+    MIN_GREATER_THAN_MAX = "min_greater_than_max"
+    INVALID_MIN_MAX = "invalid_min_max"
+    NAMING_CONVENTION = "naming_convention"
+
+
+@dataclass(frozen=True)
+class ConstraintViolation:
+    code: ConstraintCode
+    message: str
+
+    def __str__(self) -> str:
+        return self.message

--- a/src/s2dm/exporters/utils/violations.py
+++ b/src/s2dm/exporters/utils/violations.py
@@ -7,18 +7,28 @@ from enum import Enum
 class ConstraintCode(str, Enum):
     SCHEMA_SPEC = "schema.spec"
     ENUM_DEFAULT = "schema.enum_default"
+    INSTANCE_TAG_INVALID_EXCLUDE = "instanceTag.invalid_exclude"
     INSTANCE_TAG_INVALID_REFERENCE = "instanceTag.invalid_reference"
     INSTANCE_TAG_MULTIPLE_FIELDS = "instanceTag.multiple_fields"
     INSTANCE_TAG_NON_ENUM_FIELD = "instanceTag.non_enum_field"
+    INSTANCE_TAG_NOT_EXPANDED = "instanceTag.not_expanded"
+    INSTANCE_TAG_SINGLE_DIMENSION = "instanceTag.single_dimension"
+    INSTANCE_TAG_SOURCE_FIELD_TAGGED = "instanceTag.source_field_tagged"
     MIN_GREATER_THAN_MAX = "min_greater_than_max"
     INVALID_MIN_MAX = "invalid_min_max"
     NAMING_CONVENTION = "naming_convention"
+
+
+class Severity(str, Enum):
+    ERROR = "error"
+    WARNING = "warning"
 
 
 @dataclass(frozen=True)
 class ConstraintViolation:
     code: ConstraintCode
     message: str
+    severity: Severity = Severity.ERROR
 
     def __str__(self) -> str:
         return self.message

--- a/src/s2dm/exporters/vspec.py
+++ b/src/s2dm/exporters/vspec.py
@@ -15,6 +15,7 @@ from graphql import (
 )
 
 from s2dm import log
+from s2dm.constants.directive import Directive, DirectiveArgument
 from s2dm.exporters.utils.annotated_schema import AnnotatedSchema
 from s2dm.exporters.utils.directive import get_directive_arguments, has_given_directive
 from s2dm.exporters.utils.extraction import get_all_object_types
@@ -261,26 +262,26 @@ def process_field(
         }
 
         # TODO: Fix numbers that are appearing with quotes as strings.
-        if has_given_directive(field, "range"):
-            args = get_directive_arguments(field, "range")
+        if has_given_directive(field, Directive.RANGE):
+            args = get_directive_arguments(field, Directive.RANGE)
             datatype = field_dict["datatype"]
             is_integer_type = "int" in datatype
             is_float_type = datatype in ("float", "double")
 
-            if "min" in args:
+            if DirectiveArgument.MIN in args:
                 if is_integer_type:
-                    field_dict["min"] = int(args["min"])
+                    field_dict["min"] = int(args[DirectiveArgument.MIN])
                 elif is_float_type:
-                    field_dict["min"] = float(args["min"])
+                    field_dict["min"] = float(args[DirectiveArgument.MIN])
                 else:
-                    field_dict["min"] = args["min"]
-            if "max" in args:
+                    field_dict["min"] = args[DirectiveArgument.MIN]
+            if DirectiveArgument.MAX in args:
                 if is_integer_type:
-                    field_dict["max"] = int(args["max"])
+                    field_dict["max"] = int(args[DirectiveArgument.MAX])
                 elif is_float_type:
-                    field_dict["max"] = float(args["max"])
+                    field_dict["max"] = float(args[DirectiveArgument.MAX])
                 else:
-                    field_dict["max"] = args["max"]
+                    field_dict["max"] = args[DirectiveArgument.MAX]
 
         # TODO: Map the unit name. i.e., SCREAMMING_SNAKE_CASE used in graphql to abbreviated vss unit name.
         if "unit" in field.args:
@@ -288,11 +289,16 @@ def process_field(
             if unit_arg is not None and unit_arg is not Undefined and unit_arg in UNITS_DICT:
                 field_dict["unit"] = UNITS_DICT[unit_arg]
 
-        if has_given_directive(field, "metadata"):
+        if has_given_directive(field, Directive.METADATA):
             metadata_directive = None
             if field.ast_node and field.ast_node.directives:
                 metadata_directive = next(
-                    (directive for directive in field.ast_node.directives if directive.name.value == "metadata"), None
+                    (
+                        directive
+                        for directive in field.ast_node.directives
+                        if directive.name.value == Directive.METADATA
+                    ),
+                    None,
                 )
 
             metadata_args = {}
@@ -301,8 +307,8 @@ def process_field(
                     if hasattr(arg.value, "value"):  # Ensure arg.value has the 'value' attribute
                         metadata_args[arg.name.value] = arg.value.value
 
-            comment = metadata_args.get("comment")
-            vss_type = metadata_args.get("vssType")
+            comment = metadata_args.get(DirectiveArgument.COMMENT)
+            vss_type = metadata_args.get(DirectiveArgument.VSS_TYPE)
             if comment:
                 field_dict["comment"] = comment
             if vss_type:

--- a/src/s2dm/tools/constraint_checker.py
+++ b/src/s2dm/tools/constraint_checker.py
@@ -1,15 +1,170 @@
-from graphql import GraphQLEnumType, GraphQLObjectType, GraphQLSchema, get_named_type
+from graphql import (
+    GraphQLEnumType,
+    GraphQLField,
+    GraphQLInputObjectType,
+    GraphQLInterfaceType,
+    GraphQLObjectType,
+    GraphQLSchema,
+    Undefined,
+    get_named_type,
+    get_nullable_type,
+    is_list_type,
+    validate_schema,
+)
+from graphql.language.ast import DirectiveNode, EnumValueNode
 
 from s2dm.constants.directive import Directive, DirectiveArgument
 from s2dm.exporters.utils.directive import (
     get_directive_arguments,
+    get_field_with_applied_directive,
     get_objects_with_multiple_fields_with_directive,
     has_given_directive,
 )
-from s2dm.exporters.utils.instance_tag import get_instance_tag_type, is_instance_tag_field
+from s2dm.exporters.utils.instance_tag import (
+    collect_expandable_fields,
+    get_instance_tag_case,
+    get_instance_tag_type,
+    included_instances,
+    is_instance_tag_field,
+    resolve_instance_tag,
+)
 from s2dm.exporters.utils.naming_config import NamingConventionConfig
-from s2dm.exporters.utils.violations import ConstraintCode, ConstraintViolation
+from s2dm.exporters.utils.violations import ConstraintCode, ConstraintViolation, Severity
 from s2dm.tools.naming_checker import check_naming_conventions
+
+
+def _get_invalid_directive_enum_argument_values(
+    schema: GraphQLSchema, directive_node: DirectiveNode, context: str
+) -> list[str]:
+    """Find enum arguments in this directive usage whose value isn't defined by that enum."""
+    errors: list[str] = []
+
+    directive_definition = schema.get_directive(directive_node.name.value)
+    if not directive_definition:
+        return errors
+
+    for argument_node in directive_node.arguments:
+        argument_name = argument_node.name.value
+        argument_definition = directive_definition.args[argument_name]
+        named_type = get_named_type(argument_definition.type)
+
+        if not isinstance(named_type, GraphQLEnumType):
+            continue
+
+        if not isinstance(argument_node.value, EnumValueNode):
+            continue
+
+        enum_value = argument_node.value.value
+        if enum_value not in named_type.values:
+            errors.append(
+                f"{context} uses directive '@{directive_node.name.value}({argument_name})' "
+                f"with invalid enum value '{enum_value}'. Valid values are: {list(named_type.values.keys())}"
+            )
+
+    return errors
+
+
+def _get_invalid_input_field_defaults(type_name: str, input_type: GraphQLInputObjectType) -> list[str]:
+    errors: list[str] = []
+    for field_name, field in input_type.fields.items():
+        named_type = get_named_type(field.type)
+        if not isinstance(named_type, GraphQLEnumType):
+            continue
+
+        if (
+            not field.ast_node
+            or field.ast_node.default_value is None
+            or field.default_value is not Undefined
+            or not isinstance(field.ast_node.default_value, EnumValueNode)
+        ):
+            continue
+
+        invalid_value = field.ast_node.default_value.value
+        errors.append(
+            f"Input type '{type_name}.{field_name}' has invalid enum default value '{invalid_value}'. "
+            f"Valid values are: {list(named_type.values.keys())}"
+        )
+    return errors
+
+
+def _get_invalid_field_argument_defaults(type_name: str, field_name: str, field: GraphQLField) -> list[str]:
+    errors: list[str] = []
+    for argument_name, argument in field.args.items():
+        named_type = get_named_type(argument.type)
+        if not isinstance(named_type, GraphQLEnumType):
+            continue
+
+        if (
+            not argument.ast_node
+            or argument.ast_node.default_value is None
+            or argument.default_value is not Undefined
+            or not isinstance(argument.ast_node.default_value, EnumValueNode)
+        ):
+            continue
+
+        invalid_value = argument.ast_node.default_value.value
+        errors.append(
+            f"Field argument '{type_name}.{field_name}({argument_name})' "
+            f"has invalid enum default value '{invalid_value}'. "
+            f"Valid values are: {list(named_type.values.keys())}"
+        )
+    return errors
+
+
+def _get_invalid_directive_definition_defaults(schema: GraphQLSchema) -> list[str]:
+    errors: list[str] = []
+    for directive in schema.directives:
+        for argument_name, argument in directive.args.items():
+            named_type = get_named_type(argument.type)
+            if not isinstance(named_type, GraphQLEnumType):
+                continue
+
+            if (
+                not argument.ast_node
+                or not argument.ast_node.default_value
+                or argument.default_value is not Undefined
+                or not isinstance(argument.ast_node.default_value, EnumValueNode)
+            ):
+                continue
+
+            invalid_value = argument.ast_node.default_value.value
+            errors.append(
+                f"Directive definition '@{directive.name}({argument_name})' "
+                f"has invalid enum default value '{invalid_value}'. Valid values are: {list(named_type.values.keys())}"
+            )
+    return errors
+
+
+def get_enum_default_errors(schema: GraphQLSchema) -> list[str]:
+    """Check that all enum default values exist in their enum definitions."""
+    errors: list[str] = []
+
+    for type_name, type_object in schema.type_map.items():
+        if type_object.ast_node and type_object.ast_node.directives:
+            for directive_node in type_object.ast_node.directives:
+                errors.extend(
+                    _get_invalid_directive_enum_argument_values(schema, directive_node, f"Type '{type_name}'")
+                )
+
+        if isinstance(type_object, GraphQLInputObjectType):
+            errors.extend(_get_invalid_input_field_defaults(type_name, type_object))
+
+        if isinstance(type_object, GraphQLObjectType | GraphQLInterfaceType | GraphQLInputObjectType):
+            for field_name, field in type_object.fields.items():
+                if field.ast_node and field.ast_node.directives:
+                    for directive_node in field.ast_node.directives:
+                        errors.extend(
+                            _get_invalid_directive_enum_argument_values(
+                                schema, directive_node, f"Field '{type_name}.{field_name}'"
+                            )
+                        )
+
+                if isinstance(type_object, GraphQLObjectType | GraphQLInterfaceType):
+                    errors.extend(_get_invalid_field_argument_defaults(type_name, field_name, field))
+
+    errors.extend(_get_invalid_directive_definition_defaults(schema))
+
+    return errors
 
 
 class ConstraintChecker:
@@ -17,36 +172,134 @@ class ConstraintChecker:
         self.schema = schema
         self.naming_config = naming_config
 
-    def check_min_leq_max(self, objects: list[GraphQLObjectType], directive: Directive) -> list[ConstraintViolation]:
+    def check_schema_spec(self) -> list[ConstraintViolation]:
+        spec_errors = validate_schema(self.schema)
+        return [ConstraintViolation(ConstraintCode.SCHEMA_SPEC, spec_error.message) for spec_error in spec_errors]
+
+    def check_enum_defaults(self) -> list[ConstraintViolation]:
+        enum_default_errors = get_enum_default_errors(self.schema)
+        return [ConstraintViolation(ConstraintCode.ENUM_DEFAULT, error) for error in enum_default_errors]
+
+    def check_min_not_greater_than_max(
+        self, objects: list[GraphQLObjectType], directive: Directive
+    ) -> list[ConstraintViolation]:
         violations: list[ConstraintViolation] = []
-        for obj in objects:
-            for fname, field in obj.fields.items():
+        for object_type in objects:
+            for field_name, field in object_type.fields.items():
                 if has_given_directive(field, directive):
-                    args = get_directive_arguments(field, directive)
+                    arguments = get_directive_arguments(field, directive)
                     try:
-                        min_val = args.get(DirectiveArgument.MIN)
-                        max_val = args.get(DirectiveArgument.MAX)
-                        if min_val is not None and max_val is not None and float(min_val) > float(max_val):
+                        min_value = arguments.get(DirectiveArgument.MIN)
+                        max_value = arguments.get(DirectiveArgument.MAX)
+                        if min_value is not None and max_value is not None and float(min_value) > float(max_value):
                             violations.append(
                                 ConstraintViolation(
                                     ConstraintCode.MIN_GREATER_THAN_MAX,
-                                    f"[{directive.value}] {obj.name}.{fname} has min > max ({min_val} > {max_val})",
+                                    f"[{directive.value}] {object_type.name}.{field_name} has min > max "
+                                    f"({min_value} > {max_value})",
                                 )
                             )
                     except (ValueError, TypeError) as exc:
                         violations.append(
                             ConstraintViolation(
                                 ConstraintCode.INVALID_MIN_MAX,
-                                f"[{directive.value}] {obj.name}.{fname} has invalid min/max values: {exc}",
+                                f"[{directive.value}] {object_type.name}.{field_name} has invalid min/max "
+                                f"values: {exc}",
                             )
                         )
 
         return violations
 
-    def run(self, objects: list[GraphQLObjectType]) -> list[ConstraintViolation]:
+    def check_instance_tag_expandability(self, objects: list[GraphQLObjectType]) -> list[ConstraintViolation]:
         violations: list[ConstraintViolation] = []
-        for obj in objects:
-            for fname, field in obj.fields.items():
+        for object_type in objects:
+            for field_name, field in object_type.fields.items():
+                base_type = get_named_type(field.type)
+                if not isinstance(base_type, GraphQLObjectType):
+                    continue
+
+                resolved_instance_tag = resolve_instance_tag(base_type, self.schema)
+                if resolved_instance_tag is None:
+                    continue
+
+                unwrapped_type = get_nullable_type(field.type)
+                if is_list_type(unwrapped_type):
+                    continue
+
+                violations.append(
+                    ConstraintViolation(
+                        ConstraintCode.INSTANCE_TAG_NOT_EXPANDED,
+                        f"[instanceTag] {object_type.name}.{field_name}: {base_type.name} has a valid expandable "
+                        "output type but it is not expanded because it was not declared with the list "
+                        "type modifier []",
+                        severity=Severity.WARNING,
+                    )
+                )
+        return violations
+
+    def check_instance_tag_exclude_list(self) -> list[ConstraintViolation]:
+        """Check that every @instanceTag exclude entry matches a real instance.
+
+        `included_instances` raises `ValueError` when an exclude entry matches no instance; that
+        exception is the signal this method turns into a violation, one per bad entry.
+        """
+        instance_tag_case = get_instance_tag_case(self.naming_config)
+        expandable_fields = collect_expandable_fields(self.schema)
+        violations: list[ConstraintViolation] = []
+        for expandable in expandable_fields:
+            try:
+                included_instances(expandable, instance_tag_case)
+            except ValueError as exc:
+                violations.append(ConstraintViolation(ConstraintCode.INSTANCE_TAG_INVALID_EXCLUDE, str(exc)))
+        return violations
+
+    def check_instance_tag_source_type_fields(self, objects: list[GraphQLObjectType]) -> list[ConstraintViolation]:
+        violations: list[ConstraintViolation] = []
+        for object_type in objects:
+            if not has_given_directive(object_type, Directive.INSTANCE_TAG):
+                continue
+
+            tagged_fields = get_field_with_applied_directive(object_type, Directive.INSTANCE_TAG)
+            for field_name in tagged_fields:
+                violations.append(
+                    ConstraintViolation(
+                        ConstraintCode.INSTANCE_TAG_SOURCE_FIELD_TAGGED,
+                        f"[instanceTag] {object_type.name}.{field_name} must not be tagged with "
+                        "@instanceTag (in @instanceTag object)",
+                    )
+                )
+
+            for field_name, field in object_type.fields.items():
+                field_type = get_named_type(field.type)
+                if not isinstance(field_type, GraphQLEnumType):
+                    violations.append(
+                        ConstraintViolation(
+                            ConstraintCode.INSTANCE_TAG_NON_ENUM_FIELD,
+                            f"[instanceTag] {object_type.name}.{field_name} must be an enum (in @instanceTag object)",
+                        )
+                    )
+        return violations
+
+    def check_instance_tag_single_dimension(self, objects: list[GraphQLObjectType]) -> list[ConstraintViolation]:
+        violations: list[ConstraintViolation] = []
+        for object_type in objects:
+            if not has_given_directive(object_type, Directive.INSTANCE_TAG) or len(object_type.fields) != 1:
+                continue
+
+            violations.append(
+                ConstraintViolation(
+                    ConstraintCode.INSTANCE_TAG_SINGLE_DIMENSION,
+                    f"[instanceTag] type {object_type.name} @instanceTag has a single dimension. Consider "
+                    f"using a direct enum instead: enum {object_type.name} @instanceTag",
+                    severity=Severity.WARNING,
+                )
+            )
+        return violations
+
+    def check_instance_tag_reference(self, objects: list[GraphQLObjectType]) -> list[ConstraintViolation]:
+        violations: list[ConstraintViolation] = []
+        for object_type in objects:
+            for field_name, field in object_type.fields.items():
                 if not is_instance_tag_field(field):
                     continue
 
@@ -55,35 +308,40 @@ class ConstraintChecker:
                     violations.append(
                         ConstraintViolation(
                             ConstraintCode.INSTANCE_TAG_INVALID_REFERENCE,
-                            f"[instanceTag] {obj.name}.{fname} must reference an object or enum type with @instanceTag",
+                            f"[instanceTag] {object_type.name}.{field_name} must reference an object or enum "
+                            "type with @instanceTag",
                         )
                     )
+        return violations
 
-        for obj_name, field_names in get_objects_with_multiple_fields_with_directive(
+    def check_instance_tag_multiple_fields(self, objects: list[GraphQLObjectType]) -> list[ConstraintViolation]:
+        violations: list[ConstraintViolation] = []
+        objects_with_multiple_instance_tags = get_objects_with_multiple_fields_with_directive(
             objects, Directive.INSTANCE_TAG
-        ).items():
+        )
+        for object_name, field_names in objects_with_multiple_instance_tags.items():
             joined = ", ".join(field_names)
             violations.append(
                 ConstraintViolation(
                     ConstraintCode.INSTANCE_TAG_MULTIPLE_FIELDS,
-                    f"[instanceTag] {obj_name} must have at most one @instanceTag field (found: {joined})",
+                    f"[instanceTag] {object_name} must have at most one @instanceTag field (found: {joined})",
                 )
             )
+        return violations
 
-        for obj in objects:
-            if has_given_directive(obj, Directive.INSTANCE_TAG):
-                for fname, field in obj.fields.items():
-                    field_type = get_named_type(field.type)
-                    if not isinstance(field_type, GraphQLEnumType):
-                        violations.append(
-                            ConstraintViolation(
-                                ConstraintCode.INSTANCE_TAG_NON_ENUM_FIELD,
-                                f"[instanceTag] {obj.name}.{fname} must be an enum (in @instanceTag object)",
-                            )
-                        )
-
-        violations += self.check_min_leq_max(objects, Directive.RANGE)
-        violations += self.check_min_leq_max(objects, Directive.CARDINALITY)
+    def run(self, objects: list[GraphQLObjectType]) -> list[ConstraintViolation]:
+        """Run every constraint check and return all violations, errors and warnings alike."""
+        violations: list[ConstraintViolation] = []
+        violations += self.check_instance_tag_reference(objects)
+        violations += self.check_instance_tag_multiple_fields(objects)
+        violations += self.check_schema_spec()
+        violations += self.check_enum_defaults()
+        violations += self.check_instance_tag_source_type_fields(objects)
+        violations += self.check_instance_tag_expandability(objects)
+        violations += self.check_instance_tag_single_dimension(objects)
+        violations += self.check_instance_tag_exclude_list()
+        violations += self.check_min_not_greater_than_max(objects, Directive.RANGE)
+        violations += self.check_min_not_greater_than_max(objects, Directive.CARDINALITY)
 
         if self.naming_config:
             naming_errors = check_naming_conventions(self.schema, self.naming_config)

--- a/src/s2dm/tools/constraint_checker.py
+++ b/src/s2dm/tools/constraint_checker.py
@@ -6,7 +6,7 @@ from s2dm.exporters.utils.directive import (
     get_objects_with_multiple_fields_with_directive,
     has_given_directive,
 )
-from s2dm.exporters.utils.instance_tag import is_instance_tag_field
+from s2dm.exporters.utils.instance_tag import get_instance_tag_type, is_instance_tag_field
 from s2dm.exporters.utils.naming_config import NamingConventionConfig
 from s2dm.exporters.utils.violations import ConstraintCode, ConstraintViolation
 from s2dm.tools.naming_checker import check_naming_conventions
@@ -50,15 +50,12 @@ class ConstraintChecker:
                 if not is_instance_tag_field(field):
                     continue
 
-                output_type = self.schema.get_type(get_named_type(field.type).name)
-                if not (
-                    isinstance(output_type, GraphQLObjectType)
-                    and has_given_directive(output_type, Directive.INSTANCE_TAG)
-                ):
+                output_type = get_instance_tag_type(field, self.schema)
+                if output_type is None:
                     violations.append(
                         ConstraintViolation(
                             ConstraintCode.INSTANCE_TAG_INVALID_REFERENCE,
-                            f"[instanceTag] {obj.name}.{fname} must reference an object type with @instanceTag",
+                            f"[instanceTag] {obj.name}.{fname} must reference an object or enum type with @instanceTag",
                         )
                     )
 
@@ -76,7 +73,8 @@ class ConstraintChecker:
         for obj in objects:
             if has_given_directive(obj, Directive.INSTANCE_TAG):
                 for fname, field in obj.fields.items():
-                    if not isinstance(field.type, GraphQLEnumType):
+                    field_type = get_named_type(field.type)
+                    if not isinstance(field_type, GraphQLEnumType):
                         violations.append(
                             ConstraintViolation(
                                 ConstraintCode.INSTANCE_TAG_NON_ENUM_FIELD,

--- a/src/s2dm/tools/constraint_checker.py
+++ b/src/s2dm/tools/constraint_checker.py
@@ -1,7 +1,14 @@
 from graphql import GraphQLEnumType, GraphQLObjectType, GraphQLSchema, get_named_type
 
-from s2dm.exporters.utils.directive import get_directive_arguments, has_given_directive
+from s2dm.constants.directive import Directive, DirectiveArgument
+from s2dm.exporters.utils.directive import (
+    get_directive_arguments,
+    get_objects_with_multiple_fields_with_directive,
+    has_given_directive,
+)
+from s2dm.exporters.utils.instance_tag import is_instance_tag_field
 from s2dm.exporters.utils.naming_config import NamingConventionConfig
+from s2dm.exporters.utils.violations import ConstraintCode, ConstraintViolation
 from s2dm.tools.naming_checker import check_naming_conventions
 
 
@@ -10,45 +17,78 @@ class ConstraintChecker:
         self.schema = schema
         self.naming_config = naming_config
 
-    def check_min_leq_max(self, objects: list[GraphQLObjectType], directive: str) -> list[str]:
-        errors = []
+    def check_min_leq_max(self, objects: list[GraphQLObjectType], directive: Directive) -> list[ConstraintViolation]:
+        violations: list[ConstraintViolation] = []
         for obj in objects:
             for fname, field in obj.fields.items():
                 if has_given_directive(field, directive):
                     args = get_directive_arguments(field, directive)
                     try:
-                        min_val = args.get("min")
-                        max_val = args.get("max")
+                        min_val = args.get(DirectiveArgument.MIN)
+                        max_val = args.get(DirectiveArgument.MAX)
                         if min_val is not None and max_val is not None and float(min_val) > float(max_val):
-                            errors.append(f"[{directive}] {obj.name}.{fname} has min > max ({min_val} > {max_val})")
-                    except (ValueError, TypeError) as e:
-                        errors.append(f"[{directive}] {obj.name}.{fname} has invalid min/max values: {e}")
+                            violations.append(
+                                ConstraintViolation(
+                                    ConstraintCode.MIN_GREATER_THAN_MAX,
+                                    f"[{directive.value}] {obj.name}.{fname} has min > max ({min_val} > {max_val})",
+                                )
+                            )
+                    except (ValueError, TypeError) as exc:
+                        violations.append(
+                            ConstraintViolation(
+                                ConstraintCode.INVALID_MIN_MAX,
+                                f"[{directive.value}] {obj.name}.{fname} has invalid min/max values: {exc}",
+                            )
+                        )
 
-        return errors
+        return violations
 
-    def run(self, objects: list[GraphQLObjectType]) -> list[str]:
-        errors: list[str] = []
-        # instanceTag field rule
+    def run(self, objects: list[GraphQLObjectType]) -> list[ConstraintViolation]:
+        violations: list[ConstraintViolation] = []
         for obj in objects:
-            if "instanceTag" in obj.fields:
-                field = obj.fields["instanceTag"]
+            for fname, field in obj.fields.items():
+                if not is_instance_tag_field(field):
+                    continue
+
                 output_type = self.schema.get_type(get_named_type(field.type).name)
-                if not (isinstance(output_type, GraphQLObjectType) and has_given_directive(output_type, "instanceTag")):
-                    errors.append(
-                        f"[instanceTag] {obj.name}.instanceTag must reference an object type with @instanceTag"
+                if not (
+                    isinstance(output_type, GraphQLObjectType)
+                    and has_given_directive(output_type, Directive.INSTANCE_TAG)
+                ):
+                    violations.append(
+                        ConstraintViolation(
+                            ConstraintCode.INSTANCE_TAG_INVALID_REFERENCE,
+                            f"[instanceTag] {obj.name}.{fname} must reference an object type with @instanceTag",
+                        )
                     )
 
-        # instanceTag object fields must be enums
+        for obj_name, field_names in get_objects_with_multiple_fields_with_directive(
+            objects, Directive.INSTANCE_TAG
+        ).items():
+            joined = ", ".join(field_names)
+            violations.append(
+                ConstraintViolation(
+                    ConstraintCode.INSTANCE_TAG_MULTIPLE_FIELDS,
+                    f"[instanceTag] {obj_name} must have at most one @instanceTag field (found: {joined})",
+                )
+            )
+
         for obj in objects:
-            if has_given_directive(obj, "instanceTag"):
+            if has_given_directive(obj, Directive.INSTANCE_TAG):
                 for fname, field in obj.fields.items():
                     if not isinstance(field.type, GraphQLEnumType):
-                        errors.append(f"[instanceTag] {obj.name}.{fname} must be an enum (in @instanceTag object)")
+                        violations.append(
+                            ConstraintViolation(
+                                ConstraintCode.INSTANCE_TAG_NON_ENUM_FIELD,
+                                f"[instanceTag] {obj.name}.{fname} must be an enum (in @instanceTag object)",
+                            )
+                        )
 
-        errors += self.check_min_leq_max(objects, "range")
-        errors += self.check_min_leq_max(objects, "cardinality")
+        violations += self.check_min_leq_max(objects, Directive.RANGE)
+        violations += self.check_min_leq_max(objects, Directive.CARDINALITY)
 
         if self.naming_config:
-            errors += check_naming_conventions(self.schema, self.naming_config)
+            naming_errors = check_naming_conventions(self.schema, self.naming_config)
+            violations += [ConstraintViolation(ConstraintCode.NAMING_CONVENTION, error) for error in naming_errors]
 
-        return errors
+        return violations

--- a/src/s2dm/tools/naming_checker.py
+++ b/src/s2dm/tools/naming_checker.py
@@ -9,7 +9,7 @@ from graphql import (
 
 from s2dm.exporters.utils.field import FieldCase, get_field_case
 from s2dm.exporters.utils.graphql_type import is_introspection_type
-from s2dm.exporters.utils.naming import TYPE_CONTEXTS, convert_name, is_instance_tag_field
+from s2dm.exporters.utils.naming import TYPE_CONTEXTS, convert_name
 from s2dm.exporters.utils.naming_config import (
     CaseFormat,
     ContextType,
@@ -108,7 +108,7 @@ def check_naming_conventions(
             for field_name, field in object_type.fields.items():
                 if field_case:
                     matches, suggestion = _matches_case_format(field_name, field_case)
-                    if not is_instance_tag_field(field_name, field, schema) and not matches:
+                    if not matches:
                         field_errors.append(
                             f"[naming] Field '{object_type.name}.{field_name}' should be {field_case.value} "
                             f"(suggestion: '{suggestion}')"

--- a/src/s2dm/tools/naming_checker.py
+++ b/src/s2dm/tools/naming_checker.py
@@ -9,7 +9,7 @@ from graphql import (
 
 from s2dm.exporters.utils.field import FieldCase, get_field_case
 from s2dm.exporters.utils.graphql_type import is_introspection_type
-from s2dm.exporters.utils.naming import TYPE_CONTEXTS, convert_name
+from s2dm.exporters.utils.naming import TYPE_CONTEXTS, collect_instance_tag_enum_names, convert_name
 from s2dm.exporters.utils.naming_config import (
     CaseFormat,
     ContextType,
@@ -68,6 +68,7 @@ def check_naming_conventions(
     argument_errors = []
     enum_value_errors = []
     plural_errors = []
+    instance_tag_enum_names = collect_instance_tag_enum_names(schema)
 
     for type_name, object_type in schema.type_map.items():
         if is_introspection_type(type_name):
@@ -87,7 +88,10 @@ def check_naming_conventions(
                 )
 
         if isinstance(object_type, GraphQLEnumType):
-            expected_case = get_case_for_element(ElementType.ENUM_VALUE, None, config)
+            enum_element_type = (
+                ElementType.INSTANCE_TAG if type_name in instance_tag_enum_names else ElementType.ENUM_VALUE
+            )
+            expected_case = get_case_for_element(enum_element_type, None, config)
             if expected_case:
                 for value_name in object_type.values:
                     matches, suggestion = _matches_case_format(value_name, expected_case)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,6 +45,7 @@ class TestSchemaData:
     NESTED_ENUM_SCHEMA = TESTS_DATA_DIR / "nested_enum_schema.graphql"
     NESTED_INPUT_TYPE_SCHEMA = TESTS_DATA_DIR / "nested_input_type_schema.graphql"
     INSTANCE_TAG_DIRECTIVE_SCHEMA = TESTS_DATA_DIR / "instance_tag_directive_schema.graphql"
+    ENUM_INSTANCE_TAG_SCHEMA = TESTS_DATA_DIR / "enum_instance_tag_schema.graphql"
 
     # Version bump test schemas
     BASE_SCHEMA = TESTS_DATA_DIR / "base.graphql"
@@ -69,6 +70,11 @@ def parsed_console_output() -> str:
 def instance_tag_directive_schema_path() -> Path:
     """Path to a schema exercising the @instanceTag directive: Seat has two tag fields, Door has one."""
     return TestSchemaData.INSTANCE_TAG_DIRECTIVE_SCHEMA
+
+
+@pytest.fixture
+def enum_instance_tag_schema_path() -> Path:
+    return TestSchemaData.ENUM_INSTANCE_TAG_SCHEMA
 
 
 @pytest.fixture(scope="module")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,6 +44,7 @@ class TestSchemaData:
     SCHEMA1_QUERY = TESTS_DATA_DIR / "schema1_query.graphql"
     NESTED_ENUM_SCHEMA = TESTS_DATA_DIR / "nested_enum_schema.graphql"
     NESTED_INPUT_TYPE_SCHEMA = TESTS_DATA_DIR / "nested_input_type_schema.graphql"
+    INSTANCE_TAG_DIRECTIVE_SCHEMA = TESTS_DATA_DIR / "instance_tag_directive_schema.graphql"
 
     # Version bump test schemas
     BASE_SCHEMA = TESTS_DATA_DIR / "base.graphql"
@@ -62,6 +63,12 @@ def spec_directory() -> Path:
 def parsed_console_output() -> str:
     """Parse console output (placeholder function)."""
     return ""
+
+
+@pytest.fixture
+def instance_tag_directive_schema_path() -> Path:
+    """Path to a schema exercising the @instanceTag directive: Seat has two tag fields, Door has one."""
+    return TestSchemaData.INSTANCE_TAG_DIRECTIVE_SCHEMA
 
 
 @pytest.fixture(scope="module")

--- a/tests/data/enum_instance_tag_schema.graphql
+++ b/tests/data/enum_instance_tag_schema.graphql
@@ -1,0 +1,20 @@
+directive @instanceTag on OBJECT | FIELD_DEFINITION | ENUM
+
+enum MirrorPosition @instanceTag {
+  LEFT
+  CENTER
+  RIGHT
+}
+
+type Mirror {
+  position: MirrorPosition @instanceTag
+  isFolded: Boolean
+}
+
+type Vehicle {
+  mirrors: [Mirror]
+}
+
+type Query {
+  vehicle: Vehicle
+}

--- a/tests/data/enum_instance_tag_schema.graphql
+++ b/tests/data/enum_instance_tag_schema.graphql
@@ -1,4 +1,4 @@
-directive @instanceTag on OBJECT | FIELD_DEFINITION | ENUM
+directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM | ENUM
 
 enum MirrorPosition @instanceTag {
   LEFT

--- a/tests/data/instance_tag_directive_schema.graphql
+++ b/tests/data/instance_tag_directive_schema.graphql
@@ -1,0 +1,32 @@
+directive @instanceTag on OBJECT | FIELD_DEFINITION
+
+enum RowEnum {
+  ROW1
+  ROW2
+}
+
+enum SideEnum {
+  LEFT
+  RIGHT
+}
+
+type CabinPosition @instanceTag {
+  row: RowEnum!
+  side: SideEnum!
+}
+
+type Seat {
+  cabinPosition: CabinPosition @instanceTag
+  fallbackPosition: CabinPosition @instanceTag
+  isOccupied: Boolean
+}
+
+type Door {
+  cabinPosition: CabinPosition @instanceTag
+  isLocked: Boolean
+}
+
+type Query {
+  seat: Seat
+  door: Door
+}

--- a/tests/data/instance_tag_directive_schema.graphql
+++ b/tests/data/instance_tag_directive_schema.graphql
@@ -1,4 +1,4 @@
-directive @instanceTag on OBJECT | FIELD_DEFINITION
+directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM
 
 enum RowEnum {
   ROW1

--- a/tests/data/spec/common.graphql
+++ b/tests/data/spec/common.graphql
@@ -4,7 +4,7 @@ directive @cardinality(min: Int, max: Int) on FIELD_DEFINITION
 
 directive @noDuplicates on FIELD_DEFINITION
 
-directive @instanceTag on OBJECT | FIELD_DEFINITION
+directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM
 
 directive @metadata(comment: String, vssType: String) on FIELD_DEFINITION | OBJECT
 

--- a/tests/data/spec/common.graphql
+++ b/tests/data/spec/common.graphql
@@ -4,7 +4,7 @@ directive @cardinality(min: Int, max: Int) on FIELD_DEFINITION
 
 directive @noDuplicates on FIELD_DEFINITION
 
-directive @instanceTag on OBJECT
+directive @instanceTag on OBJECT | FIELD_DEFINITION
 
 directive @metadata(comment: String, vssType: String) on FIELD_DEFINITION | OBJECT
 

--- a/tests/test_avro_idl.py
+++ b/tests/test_avro_idl.py
@@ -378,7 +378,7 @@ class TestStrictMode:
         """Test that strict mode includes enum definitions used by @instanceTag types."""
         schema_str = """
         directive @vspec(element: VspecElement!) on OBJECT
-        directive @instanceTag on OBJECT | FIELD_DEFINITION
+        directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM
 
         enum VspecElement {
             STRUCT

--- a/tests/test_avro_idl.py
+++ b/tests/test_avro_idl.py
@@ -378,7 +378,7 @@ class TestStrictMode:
         """Test that strict mode includes enum definitions used by @instanceTag types."""
         schema_str = """
         directive @vspec(element: VspecElement!) on OBJECT
-        directive @instanceTag on OBJECT
+        directive @instanceTag on OBJECT | FIELD_DEFINITION
 
         enum VspecElement {
             STRUCT
@@ -402,7 +402,7 @@ class TestStrictMode:
         type Door {
             isLocked: Boolean
             position: Int
-            instanceTag: DoorPosition
+            doorPosition: DoorPosition @instanceTag
         }
 
         type Vehicle @vspec(element: STRUCT) {

--- a/tests/test_check_constraint.py
+++ b/tests/test_check_constraint.py
@@ -1,6 +1,7 @@
 from graphql import GraphQLObjectType, GraphQLSchema, build_schema
 
 from s2dm.exporters.utils.extraction import get_all_object_types
+from s2dm.exporters.utils.violations import ConstraintCode
 from s2dm.tools.constraint_checker import ConstraintChecker
 
 
@@ -15,7 +16,7 @@ def get_objects(schema: GraphQLSchema) -> list[GraphQLObjectType]:
 
 def test_instance_tag_field_must_reference_instance_tag_object() -> None:
     sdl = """
-    directive @instanceTag on OBJECT
+    directive @instanceTag on OBJECT | FIELD_DEFINITION
 
     type TagObj @instanceTag {
       level: TagEnum
@@ -23,52 +24,94 @@ def test_instance_tag_field_must_reference_instance_tag_object() -> None:
     enum TagEnum { A B }
 
     type Foo {
-      instanceTag: TagObj
+      tag: TagObj @instanceTag
     }
     """
     schema = make_schema(sdl)
     objects = get_objects(schema)
     checker = ConstraintChecker(schema)
-    errors = checker.run(objects)
-    assert not errors
+    violations = checker.run(objects)
+    assert not violations
 
 
 def test_instance_tag_field_wrong_type() -> None:
     sdl = """
-    directive @instanceTag on OBJECT
+    directive @instanceTag on OBJECT | FIELD_DEFINITION
 
     type NotTagObj {
       foo: String
     }
 
     type Foo {
-      instanceTag: NotTagObj
+      tag: NotTagObj @instanceTag
     }
     """
     schema = make_schema(sdl)
     objects = get_objects(schema)
     checker = ConstraintChecker(schema)
-    errors = checker.run(objects)
-    assert any("must reference an object type with @instanceTag" in e for e in errors)
+    violations = checker.run(objects)
+    assert any(violation.code == ConstraintCode.INSTANCE_TAG_INVALID_REFERENCE for violation in violations)
 
 
 def test_instance_tag_object_fields_must_be_enum() -> None:
     sdl = """
-    directive @instanceTag on OBJECT
+    directive @instanceTag on OBJECT | FIELD_DEFINITION
 
     type TagObj @instanceTag {
       notEnum: String
     }
 
     type Foo {
-      instanceTag: TagObj
+      tag: TagObj @instanceTag
     }
     """
     schema = make_schema(sdl)
     objects = get_objects(schema)
     checker = ConstraintChecker(schema)
-    errors = checker.run(objects)
-    assert any("must be an enum" in e for e in errors)
+    violations = checker.run(objects)
+    assert any(violation.code == ConstraintCode.INSTANCE_TAG_NON_ENUM_FIELD for violation in violations)
+
+
+def test_instance_tag_at_most_one_field_per_type() -> None:
+    sdl = """
+    directive @instanceTag on OBJECT | FIELD_DEFINITION
+
+    type TagObj @instanceTag {
+      level: TagEnum
+    }
+    enum TagEnum { A B }
+
+    type Foo {
+      tag1: TagObj @instanceTag
+      tag2: TagObj @instanceTag
+    }
+    """
+    schema = make_schema(sdl)
+    objects = get_objects(schema)
+    checker = ConstraintChecker(schema)
+    violations = checker.run(objects)
+    assert any(violation.code == ConstraintCode.INSTANCE_TAG_MULTIPLE_FIELDS for violation in violations)
+
+
+def test_instance_tag_single_field_is_allowed() -> None:
+    sdl = """
+    directive @instanceTag on OBJECT | FIELD_DEFINITION
+
+    type TagObj @instanceTag {
+      level: TagEnum
+    }
+    enum TagEnum { A B }
+
+    type Foo {
+      tag: TagObj @instanceTag
+      other: String
+    }
+    """
+    schema = make_schema(sdl)
+    objects = get_objects(schema)
+    checker = ConstraintChecker(schema)
+    violations = checker.run(objects)
+    assert not violations
 
 
 def test_range_min_leq_max() -> None:
@@ -82,8 +125,8 @@ def test_range_min_leq_max() -> None:
     schema = make_schema(sdl)
     objects = get_objects(schema)
     checker = ConstraintChecker(schema)
-    errors = checker.run(objects)
-    assert not errors
+    violations = checker.run(objects)
+    assert not violations
 
 
 def test_range_min_gt_max() -> None:
@@ -97,8 +140,8 @@ def test_range_min_gt_max() -> None:
     schema = make_schema(sdl)
     objects = get_objects(schema)
     checker = ConstraintChecker(schema)
-    errors = checker.run(objects)
-    assert any("has min > max" in e for e in errors)
+    violations = checker.run(objects)
+    assert any(violation.code == ConstraintCode.MIN_GREATER_THAN_MAX for violation in violations)
 
 
 def test_cardinality_min_leq_max() -> None:
@@ -112,8 +155,8 @@ def test_cardinality_min_leq_max() -> None:
     schema = make_schema(sdl)
     objects = get_objects(schema)
     checker = ConstraintChecker(schema)
-    errors = checker.run(objects)
-    assert not errors
+    violations = checker.run(objects)
+    assert not violations
 
 
 def test_cardinality_min_gt_max() -> None:
@@ -127,5 +170,5 @@ def test_cardinality_min_gt_max() -> None:
     schema = make_schema(sdl)
     objects = get_objects(schema)
     checker = ConstraintChecker(schema)
-    errors = checker.run(objects)
-    assert any("has min > max" in e for e in errors)
+    violations = checker.run(objects)
+    assert any(violation.code == ConstraintCode.MIN_GREATER_THAN_MAX for violation in violations)

--- a/tests/test_check_constraint.py
+++ b/tests/test_check_constraint.py
@@ -114,6 +114,46 @@ def test_instance_tag_single_field_is_allowed() -> None:
     assert not violations
 
 
+def test_instance_tag_field_may_reference_instance_tag_enum() -> None:
+    sdl = """
+    directive @instanceTag on OBJECT | FIELD_DEFINITION | ENUM
+
+    enum TagEnum @instanceTag {
+      A
+      B
+    }
+
+    type Foo {
+      tag: TagEnum @instanceTag
+    }
+    """
+    schema = make_schema(sdl)
+    objects = get_objects(schema)
+    checker = ConstraintChecker(schema)
+    violations = checker.run(objects)
+    assert not violations
+
+
+def test_instance_tag_field_referencing_plain_enum_is_invalid() -> None:
+    sdl = """
+    directive @instanceTag on OBJECT | FIELD_DEFINITION | ENUM
+
+    enum TagEnum {
+      A
+      B
+    }
+
+    type Foo {
+      tag: TagEnum @instanceTag
+    }
+    """
+    schema = make_schema(sdl)
+    objects = get_objects(schema)
+    checker = ConstraintChecker(schema)
+    violations = checker.run(objects)
+    assert any(violation.code == ConstraintCode.INSTANCE_TAG_INVALID_REFERENCE for violation in violations)
+
+
 def test_range_min_leq_max() -> None:
     sdl = """
     directive @range(min: Float, max: Float) on FIELD_DEFINITION

--- a/tests/test_check_constraint.py
+++ b/tests/test_check_constraint.py
@@ -16,7 +16,7 @@ def get_objects(schema: GraphQLSchema) -> list[GraphQLObjectType]:
 
 def test_instance_tag_field_must_reference_instance_tag_object() -> None:
     sdl = """
-    directive @instanceTag on OBJECT | FIELD_DEFINITION
+    directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM
 
     type TagObj @instanceTag {
       level: TagEnum
@@ -36,7 +36,7 @@ def test_instance_tag_field_must_reference_instance_tag_object() -> None:
 
 def test_instance_tag_field_wrong_type() -> None:
     sdl = """
-    directive @instanceTag on OBJECT | FIELD_DEFINITION
+    directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM
 
     type NotTagObj {
       foo: String
@@ -55,7 +55,7 @@ def test_instance_tag_field_wrong_type() -> None:
 
 def test_instance_tag_object_fields_must_be_enum() -> None:
     sdl = """
-    directive @instanceTag on OBJECT | FIELD_DEFINITION
+    directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM
 
     type TagObj @instanceTag {
       notEnum: String
@@ -74,7 +74,7 @@ def test_instance_tag_object_fields_must_be_enum() -> None:
 
 def test_instance_tag_at_most_one_field_per_type() -> None:
     sdl = """
-    directive @instanceTag on OBJECT | FIELD_DEFINITION
+    directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM
 
     type TagObj @instanceTag {
       level: TagEnum
@@ -95,7 +95,7 @@ def test_instance_tag_at_most_one_field_per_type() -> None:
 
 def test_instance_tag_single_field_is_allowed() -> None:
     sdl = """
-    directive @instanceTag on OBJECT | FIELD_DEFINITION
+    directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM
 
     type TagObj @instanceTag {
       level: TagEnum
@@ -116,7 +116,7 @@ def test_instance_tag_single_field_is_allowed() -> None:
 
 def test_instance_tag_field_may_reference_instance_tag_enum() -> None:
     sdl = """
-    directive @instanceTag on OBJECT | FIELD_DEFINITION | ENUM
+    directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM | ENUM
 
     enum TagEnum @instanceTag {
       A
@@ -136,7 +136,7 @@ def test_instance_tag_field_may_reference_instance_tag_enum() -> None:
 
 def test_instance_tag_field_referencing_plain_enum_is_invalid() -> None:
     sdl = """
-    directive @instanceTag on OBJECT | FIELD_DEFINITION | ENUM
+    directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM | ENUM
 
     enum TagEnum {
       A

--- a/tests/test_check_constraint.py
+++ b/tests/test_check_constraint.py
@@ -1,7 +1,7 @@
 from graphql import GraphQLObjectType, GraphQLSchema, build_schema
 
 from s2dm.exporters.utils.extraction import get_all_object_types
-from s2dm.exporters.utils.violations import ConstraintCode
+from s2dm.exporters.utils.violations import ConstraintCode, Severity
 from s2dm.tools.constraint_checker import ConstraintChecker
 
 
@@ -18,32 +18,36 @@ def test_instance_tag_field_must_reference_instance_tag_object() -> None:
     sdl = """
     directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM
 
-    type TagObj @instanceTag {
-      level: TagEnum
+    type Query {
+      ping: String
     }
-    enum TagEnum { A B }
 
-    type Foo {
-      tag: TagObj @instanceTag
+    type SeatPosition @instanceTag {
+      level: HeightLevel
+    }
+    enum HeightLevel { LOW HIGH }
+
+    type Vehicle {
+      position: SeatPosition @instanceTag
     }
     """
     schema = make_schema(sdl)
     objects = get_objects(schema)
     checker = ConstraintChecker(schema)
     violations = checker.run(objects)
-    assert not violations
+    assert not any(violation.code == ConstraintCode.INSTANCE_TAG_INVALID_REFERENCE for violation in violations)
 
 
 def test_instance_tag_field_wrong_type() -> None:
     sdl = """
     directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM
 
-    type NotTagObj {
-      foo: String
+    type EngineSpecs {
+      power: String
     }
 
-    type Foo {
-      tag: NotTagObj @instanceTag
+    type Vehicle {
+      engine: EngineSpecs @instanceTag
     }
     """
     schema = make_schema(sdl)
@@ -57,12 +61,12 @@ def test_instance_tag_object_fields_must_be_enum() -> None:
     sdl = """
     directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM
 
-    type TagObj @instanceTag {
+    type SeatPosition @instanceTag {
       notEnum: String
     }
 
-    type Foo {
-      tag: TagObj @instanceTag
+    type Vehicle {
+      position: SeatPosition @instanceTag
     }
     """
     schema = make_schema(sdl)
@@ -72,18 +76,58 @@ def test_instance_tag_object_fields_must_be_enum() -> None:
     assert any(violation.code == ConstraintCode.INSTANCE_TAG_NON_ENUM_FIELD for violation in violations)
 
 
+def test_instance_tag_source_type_field_cannot_be_tagged() -> None:
+    sdl = """
+    directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM
+
+    type SeatPosition @instanceTag {
+      level: HeightLevel @instanceTag
+    }
+    enum HeightLevel { LOW HIGH }
+
+    type Vehicle {
+      position: SeatPosition @instanceTag
+    }
+    """
+    schema = make_schema(sdl)
+    objects = get_objects(schema)
+    checker = ConstraintChecker(schema)
+    violations = checker.run(objects)
+    assert any(violation.code == ConstraintCode.INSTANCE_TAG_SOURCE_FIELD_TAGGED for violation in violations)
+
+
+def test_instance_tag_source_type_field_not_tagged_is_valid() -> None:
+    sdl = """
+    directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM
+
+    type SeatPosition @instanceTag {
+      level: HeightLevel
+    }
+    enum HeightLevel { LOW HIGH }
+
+    type Vehicle {
+      position: SeatPosition @instanceTag
+    }
+    """
+    schema = make_schema(sdl)
+    objects = get_objects(schema)
+    checker = ConstraintChecker(schema)
+    violations = checker.run(objects)
+    assert not any(violation.code == ConstraintCode.INSTANCE_TAG_SOURCE_FIELD_TAGGED for violation in violations)
+
+
 def test_instance_tag_at_most_one_field_per_type() -> None:
     sdl = """
     directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM
 
-    type TagObj @instanceTag {
-      level: TagEnum
+    type SeatPosition @instanceTag {
+      level: HeightLevel
     }
-    enum TagEnum { A B }
+    enum HeightLevel { LOW HIGH }
 
-    type Foo {
-      tag1: TagObj @instanceTag
-      tag2: TagObj @instanceTag
+    type Vehicle {
+      position: SeatPosition @instanceTag
+      trim: SeatPosition @instanceTag
     }
     """
     schema = make_schema(sdl)
@@ -97,34 +141,42 @@ def test_instance_tag_single_field_is_allowed() -> None:
     sdl = """
     directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM
 
-    type TagObj @instanceTag {
-      level: TagEnum
+    type Query {
+      ping: String
     }
-    enum TagEnum { A B }
 
-    type Foo {
-      tag: TagObj @instanceTag
-      other: String
+    type SeatPosition @instanceTag {
+      level: HeightLevel
+    }
+    enum HeightLevel { LOW HIGH }
+
+    type Vehicle {
+      position: SeatPosition @instanceTag
+      model: String
     }
     """
     schema = make_schema(sdl)
     objects = get_objects(schema)
     checker = ConstraintChecker(schema)
     violations = checker.run(objects)
-    assert not violations
+    assert not any(violation.code == ConstraintCode.INSTANCE_TAG_MULTIPLE_FIELDS for violation in violations)
 
 
 def test_instance_tag_field_may_reference_instance_tag_enum() -> None:
     sdl = """
     directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM | ENUM
 
-    enum TagEnum @instanceTag {
-      A
-      B
+    type Query {
+      ping: String
     }
 
-    type Foo {
-      tag: TagEnum @instanceTag
+    enum HeightLevel @instanceTag {
+      LOW
+      HIGH
+    }
+
+    type Vehicle {
+      position: HeightLevel @instanceTag
     }
     """
     schema = make_schema(sdl)
@@ -138,13 +190,13 @@ def test_instance_tag_field_referencing_plain_enum_is_invalid() -> None:
     sdl = """
     directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM | ENUM
 
-    enum TagEnum {
-      A
-      B
+    enum HeightLevel {
+      LOW
+      HIGH
     }
 
-    type Foo {
-      tag: TagEnum @instanceTag
+    type Vehicle {
+      position: HeightLevel @instanceTag
     }
     """
     schema = make_schema(sdl)
@@ -154,12 +206,274 @@ def test_instance_tag_field_referencing_plain_enum_is_invalid() -> None:
     assert any(violation.code == ConstraintCode.INSTANCE_TAG_INVALID_REFERENCE for violation in violations)
 
 
+def test_instance_tag_expandable_field_not_list_warns() -> None:
+    sdl = """
+    directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM
+
+    type SeatPosition @instanceTag {
+      level: HeightLevel
+    }
+    enum HeightLevel { LOW HIGH }
+
+    type Door {
+      position: SeatPosition @instanceTag
+      isLocked: Boolean
+    }
+
+    type Cabin {
+      door: Door
+    }
+    """
+    schema = make_schema(sdl)
+    objects = get_objects(schema)
+    checker = ConstraintChecker(schema)
+    violations = checker.run(objects)
+    warning = next(v for v in violations if v.code == ConstraintCode.INSTANCE_TAG_NOT_EXPANDED)
+    assert warning.severity == Severity.WARNING
+
+
+def test_instance_tag_expandable_field_as_list_does_not_warn() -> None:
+    sdl = """
+    directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM
+
+    type SeatPosition @instanceTag {
+      level: HeightLevel
+    }
+    enum HeightLevel { LOW HIGH }
+
+    type Door {
+      position: SeatPosition @instanceTag
+      isLocked: Boolean
+    }
+
+    type Cabin {
+      doors: [Door]
+    }
+    """
+    schema = make_schema(sdl)
+    objects = get_objects(schema)
+    checker = ConstraintChecker(schema)
+    violations = checker.run(objects)
+    assert not any(v.code == ConstraintCode.INSTANCE_TAG_NOT_EXPANDED for v in violations)
+
+
+def test_instance_tag_single_dimension_warns() -> None:
+    sdl = """
+    directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM
+
+    type Query {
+      ping: String
+    }
+
+    type SeatPosition @instanceTag {
+      level: HeightLevel
+    }
+    enum HeightLevel { LOW HIGH }
+
+    type Vehicle {
+      position: SeatPosition @instanceTag
+    }
+    """
+    schema = make_schema(sdl)
+    objects = get_objects(schema)
+    checker = ConstraintChecker(schema)
+    violations = checker.run(objects)
+    warning = next(v for v in violations if v.code == ConstraintCode.INSTANCE_TAG_SINGLE_DIMENSION)
+    assert warning.severity == Severity.WARNING
+
+
+def test_instance_tag_multiple_dimensions_does_not_warn() -> None:
+    sdl = """
+    directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM
+
+    type Query {
+      ping: String
+    }
+
+    type SeatPosition @instanceTag {
+      row: RowEnum
+      level: HeightLevel
+    }
+    enum RowEnum { ROW1 ROW2 }
+    enum HeightLevel { LOW HIGH }
+
+    type Vehicle {
+      position: SeatPosition @instanceTag
+    }
+    """
+    schema = make_schema(sdl)
+    objects = get_objects(schema)
+    checker = ConstraintChecker(schema)
+    violations = checker.run(objects)
+    assert not any(v.code == ConstraintCode.INSTANCE_TAG_SINGLE_DIMENSION for v in violations)
+
+
+def test_instance_tag_exclude_list_invalid_entry_flagged() -> None:
+    sdl = """
+    directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM
+
+    type Query {
+      ping: String
+    }
+
+    type SeatPosition @instanceTag {
+      row: RowEnum
+    }
+    enum RowEnum { ROW1 ROW2 }
+
+    type Door {
+      position: SeatPosition @instanceTag(exclude: ["ROW3"])
+    }
+
+    type Cabin {
+      doors: [Door]
+    }
+    """
+    schema = make_schema(sdl)
+    objects = get_objects(schema)
+    checker = ConstraintChecker(schema)
+    violations = checker.run(objects)
+    assert any(violation.code == ConstraintCode.INSTANCE_TAG_INVALID_EXCLUDE for violation in violations)
+
+
+def test_instance_tag_exclude_list_valid_entry_not_flagged() -> None:
+    sdl = """
+    directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM
+
+    type Query {
+      ping: String
+    }
+
+    type SeatPosition @instanceTag {
+      row: RowEnum
+    }
+    enum RowEnum { ROW1 ROW2 }
+
+    type Door {
+      position: SeatPosition @instanceTag(exclude: ["ROW1"])
+    }
+
+    type Cabin {
+      doors: [Door]
+    }
+    """
+    schema = make_schema(sdl)
+    objects = get_objects(schema)
+    checker = ConstraintChecker(schema)
+    violations = checker.run(objects)
+    assert not any(violation.code == ConstraintCode.INSTANCE_TAG_INVALID_EXCLUDE for violation in violations)
+
+
+def test_run_includes_schema_spec_violations() -> None:
+    sdl = """
+    type Query {
+      vehicle: Vehicle
+    }
+
+    interface Node {
+      id: ID
+    }
+
+    type Vehicle implements Node {
+      name: String
+    }
+    """
+    schema = make_schema(sdl)
+    objects = get_objects(schema)
+    checker = ConstraintChecker(schema)
+    violations = checker.run(objects)
+    assert any(violation.code == ConstraintCode.SCHEMA_SPEC for violation in violations)
+
+
+def test_run_includes_enum_default_violations() -> None:
+    sdl = """
+    enum Color { RED BLUE }
+
+    type Query {
+      foo: String
+    }
+
+    input VehicleInput {
+      color: Color = GREEN
+    }
+    """
+    schema = make_schema(sdl)
+    objects = get_objects(schema)
+    checker = ConstraintChecker(schema)
+    violations = checker.run(objects)
+    assert any(violation.code == ConstraintCode.ENUM_DEFAULT for violation in violations)
+
+
+def test_check_schema_spec_flags_invalid_schema() -> None:
+    sdl = """
+    type Query {
+      vehicle: Vehicle
+    }
+
+    interface Node {
+      id: ID
+    }
+
+    type Vehicle implements Node {
+      name: String
+    }
+    """
+    schema = make_schema(sdl)
+    checker = ConstraintChecker(schema)
+    violations = checker.check_schema_spec()
+    assert any(violation.code == ConstraintCode.SCHEMA_SPEC for violation in violations)
+
+
+def test_check_schema_spec_allows_valid_schema() -> None:
+    sdl = """
+    type Query {
+      foo: String
+    }
+    """
+    schema = make_schema(sdl)
+    checker = ConstraintChecker(schema)
+    violations = checker.check_schema_spec()
+    assert not violations
+
+
+def test_check_enum_defaults_flags_invalid_default() -> None:
+    sdl = """
+    enum Color { RED BLUE }
+
+    input VehicleInput {
+      color: Color = GREEN
+    }
+    """
+    schema = make_schema(sdl)
+    checker = ConstraintChecker(schema)
+    violations = checker.check_enum_defaults()
+    assert any(violation.code == ConstraintCode.ENUM_DEFAULT for violation in violations)
+
+
+def test_check_enum_defaults_allows_valid_default() -> None:
+    sdl = """
+    enum Color { RED BLUE }
+
+    input VehicleInput {
+      color: Color = RED
+    }
+    """
+    schema = make_schema(sdl)
+    checker = ConstraintChecker(schema)
+    violations = checker.check_enum_defaults()
+    assert not violations
+
+
 def test_range_min_leq_max() -> None:
     sdl = """
     directive @range(min: Float, max: Float) on FIELD_DEFINITION
 
-    type Foo {
-      bar: Int @range(min: 0, max: 10)
+    type Query {
+      ping: String
+    }
+
+    type Vehicle {
+      topSpeed: Int @range(min: 0, max: 10)
     }
     """
     schema = make_schema(sdl)
@@ -173,8 +487,8 @@ def test_range_min_gt_max() -> None:
     sdl = """
     directive @range(min: Float, max: Float) on FIELD_DEFINITION
 
-    type Foo {
-      bar: Int @range(min: 10, max: 5)
+    type Vehicle {
+      topSpeed: Int @range(min: 10, max: 5)
     }
     """
     schema = make_schema(sdl)
@@ -188,8 +502,12 @@ def test_cardinality_min_leq_max() -> None:
     sdl = """
     directive @cardinality(min: Int, max: Int) on FIELD_DEFINITION
 
-    type Foo {
-      bar: Int @cardinality(min: 0, max: 2)
+    type Query {
+      ping: String
+    }
+
+    type Vehicle {
+      doorCount: Int @cardinality(min: 0, max: 2)
     }
     """
     schema = make_schema(sdl)
@@ -203,8 +521,8 @@ def test_cardinality_min_gt_max() -> None:
     sdl = """
     directive @cardinality(min: Int, max: Int) on FIELD_DEFINITION
 
-    type Foo {
-      bar: Int @cardinality(min: 3, max: 2)
+    type Vehicle {
+      doorCount: Int @cardinality(min: 3, max: 2)
     }
     """
     schema = make_schema(sdl)

--- a/tests/test_directive.py
+++ b/tests/test_directive.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+
+from graphql import GraphQLObjectType, build_schema
+
+from s2dm.constants.directive import Directive
+from s2dm.exporters.utils.directive import (
+    get_field_with_applied_directive,
+    get_objects_with_multiple_fields_with_directive,
+)
+from s2dm.exporters.utils.extraction import get_all_object_types
+
+
+def test_get_field_with_applied_directive_returns_matching_fields(instance_tag_directive_schema_path: Path) -> None:
+    schema = build_schema(instance_tag_directive_schema_path.read_text())
+    seat = schema.type_map["Seat"]
+    assert isinstance(seat, GraphQLObjectType)
+    assert set(get_field_with_applied_directive(seat, Directive.INSTANCE_TAG)) == {"cabinPosition", "fallbackPosition"}
+
+
+def test_get_objects_with_multiple_fields_with_directive(instance_tag_directive_schema_path: Path) -> None:
+    schema = build_schema(instance_tag_directive_schema_path.read_text())
+    objects = get_all_object_types(schema)
+    result = get_objects_with_multiple_fields_with_directive(objects, Directive.INSTANCE_TAG)
+    # Seat declares two @instanceTag fields; Door (one) and CabinPosition (none) are not flagged.
+    assert result == {"Seat": ["cabinPosition", "fallbackPosition"]}

--- a/tests/test_e2e_avro_idl.py
+++ b/tests/test_e2e_avro_idl.py
@@ -53,7 +53,7 @@ class TestAvroIDLE2EExpandedInstances:
             r"record\s+Door\s*\{.*?"
             r"boolean\?\s+isLocked;.*?"
             r"int\?\s+position;.*?"
-            r"DoorPosition\?\s+instanceTag;.*?"
+            r"DoorPosition\?\s+doorPosition;.*?"
             r"\}.*?"
             r"\}",
             cabin_idl,
@@ -76,7 +76,7 @@ class TestAvroIDLE2EExpandedInstances:
             r"record\s+Seat\s*\{.*?"
             r"boolean\?\s+isOccupied;.*?"
             r"int\?\s+height;.*?"
-            r"SeatPosition\?\s+instanceTag;.*?"
+            r"SeatPosition\?\s+seatPosition;.*?"
             r"\}.*?"
             r"\}",
             cabin_idl,

--- a/tests/test_e2e_cli.py
+++ b/tests/test_e2e_cli.py
@@ -1693,7 +1693,7 @@ def test_compose_preserves_custom_directives(
     assert "directive @range(min: Float, max: Float) on FIELD_DEFINITION" in composed_content
     assert "directive @cardinality(min: Int, max: Int) on FIELD_DEFINITION" in composed_content
     assert "directive @noDuplicates on FIELD_DEFINITION" in composed_content
-    assert "directive @instanceTag on OBJECT" in composed_content
+    assert "directive @instanceTag on OBJECT | FIELD_DEFINITION" in composed_content
 
     assert "type Vehicle" in composed_content
     assert "type Vehicle_ADAS_ObstacleDetection" in composed_content

--- a/tests/test_e2e_cli.py
+++ b/tests/test_e2e_cli.py
@@ -1057,6 +1057,108 @@ def test_check_constraints(
     assert result.exit_code in (0, 1)
 
 
+def test_check_constraints_instance_tag_warning_succeeds(runner: CliRunner, tmp_path: Path) -> None:
+    schema_path = tmp_path / "non_list_instance_tag.graphql"
+    schema_path.write_text("""
+    directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM
+
+    type SeatPosition @instanceTag {
+      level: HeightLevel
+    }
+    enum HeightLevel { LOW HIGH }
+
+    type Door {
+      position: SeatPosition @instanceTag
+    }
+
+    type Cabin {
+      door: Door
+    }
+    """)
+
+    result = runner.invoke(cli, ["check", "constraints", "-s", str(schema_path)])
+
+    assert result.exit_code == 0, result.output
+
+
+def test_check_constraints_instance_tag_error_fails(runner: CliRunner, tmp_path: Path) -> None:
+    schema_path = tmp_path / "non_list_instance_tag_with_error.graphql"
+    schema_path.write_text("""
+    directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM
+
+    type SeatPosition @instanceTag {
+      level: HeightLevel
+    }
+    enum HeightLevel { LOW HIGH }
+
+    type Door {
+      position: SeatPosition @instanceTag
+    }
+
+    type Cabin {
+      door: Door
+    }
+
+    type EngineSpecs {
+      power: String
+    }
+
+    type Vehicle {
+      engine: EngineSpecs @instanceTag
+    }
+    """)
+
+    result = runner.invoke(cli, ["check", "constraints", "-s", str(schema_path)])
+
+    assert result.exit_code == 1
+
+
+def test_compose_instance_tag_warning_succeeds(runner: CliRunner, tmp_path: Path) -> None:
+    schema_path = tmp_path / "non_list_instance_tag.graphql"
+    schema_path.write_text("""
+    directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM
+
+    type SeatPosition @instanceTag {
+      level: HeightLevel
+    }
+    enum HeightLevel { LOW HIGH }
+
+    type Door {
+      position: SeatPosition @instanceTag
+    }
+
+    type Cabin {
+      door: Door
+    }
+    """)
+    output_path = tmp_path / "output.graphql"
+
+    result = runner.invoke(cli, ["compose", "-s", str(schema_path), "-o", str(output_path)])
+
+    assert result.exit_code == 0, result.output
+    assert output_path.exists()
+
+
+def test_compose_instance_tag_error_fails(runner: CliRunner, tmp_path: Path) -> None:
+    schema_path = tmp_path / "instance_tag_with_error.graphql"
+    schema_path.write_text("""
+    directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM
+
+    type EngineSpecs {
+      power: String
+    }
+
+    type Vehicle {
+      engine: EngineSpecs @instanceTag
+    }
+    """)
+    output_path = tmp_path / "output.graphql"
+
+    result = runner.invoke(cli, ["compose", "-s", str(schema_path), "-o", str(output_path)])
+
+    assert result.exit_code == 1
+
+
 def test_validate_graphql(runner: CliRunner, tmp_outputs: Path, spec_directory: Path, units_directory: Path) -> None:
     out = tmp_outputs / "validate.json"
     result = runner.invoke(
@@ -1747,6 +1849,8 @@ def test_compose_reference_directive_placement_after_other_directives(
 
     schema_file = test_schema_dir / "test.graphql"
     schema_file.write_text("""
+directive @tag on OBJECT
+
 scalar DateTime
 
 interface Node {
@@ -1763,7 +1867,7 @@ type User implements Node {
   name: String
 }
 
-type Admin implements Node & Timestamped @instanceTag {
+type Admin implements Node & Timestamped @tag {
   id: ID!
   role: String
   createdAt: String
@@ -1780,9 +1884,7 @@ union Person = User | Admin
     composed_content = out.read_text()
 
     assert 'type User implements Node @reference(source: "test.graphql")' in composed_content
-    assert (
-        'type Admin implements Node & Timestamped @instanceTag @reference(source: "test.graphql")' in composed_content
-    )
+    assert 'type Admin implements Node & Timestamped @tag @reference(source: "test.graphql")' in composed_content
 
     assert 'scalar DateTime @reference(source: "test.graphql")' in composed_content
     assert 'union Person @reference(source: "test.graphql")' in composed_content

--- a/tests/test_e2e_cli.py
+++ b/tests/test_e2e_cli.py
@@ -1693,7 +1693,7 @@ def test_compose_preserves_custom_directives(
     assert "directive @range(min: Float, max: Float) on FIELD_DEFINITION" in composed_content
     assert "directive @cardinality(min: Int, max: Int) on FIELD_DEFINITION" in composed_content
     assert "directive @noDuplicates on FIELD_DEFINITION" in composed_content
-    assert "directive @instanceTag on OBJECT | FIELD_DEFINITION" in composed_content
+    assert "directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM" in composed_content
 
     assert "type Vehicle" in composed_content
     assert "type Vehicle_ADAS_ObstacleDetection" in composed_content

--- a/tests/test_e2e_jsonschema.py
+++ b/tests/test_e2e_jsonschema.py
@@ -125,7 +125,7 @@ class TestJsonSchemaE2E:
 
         type Door {
           isLocked: Boolean
-          instanceTag: DoorPosition
+          doorPosition: DoorPosition @instanceTag
         }
 
         type RegularItem {

--- a/tests/test_enum_validation.py
+++ b/tests/test_enum_validation.py
@@ -1,6 +1,6 @@
 from graphql import build_schema
 
-from s2dm.exporters.utils.schema_loader import check_enum_defaults
+from s2dm.tools.constraint_checker import get_enum_default_errors as check_enum_defaults
 
 
 class TestEnumDefaultValidation:

--- a/tests/test_expanded_instances/test_nested_schema.graphql
+++ b/tests/test_expanded_instances/test_nested_schema.graphql
@@ -21,12 +21,12 @@ type Chassis {
 }
 
 type Axle {
-  instanceTag: ChassisAxleRowTag
+  chassisAxleRow: ChassisAxleRowTag @instanceTag
   Wheels: [Wheel] @noDuplicates
 }
 
 type Wheel {
-  instanceTag: LateralPositionTag
+  lateralPosition: LateralPositionTag @instanceTag
   Tire: Tire
 }
 

--- a/tests/test_expanded_instances/test_schema.graphql
+++ b/tests/test_expanded_instances/test_schema.graphql
@@ -22,7 +22,7 @@ type DoorPosition @instanceTag {
 type Door {
   isLocked: Boolean
   position: Int @range(min: 0, max: 100)
-  instanceTag: DoorPosition
+  doorPosition: DoorPosition @instanceTag
 }
 
 type Vehicle @vspec(element: STRUCT) {
@@ -52,7 +52,7 @@ type SeatPosition @instanceTag {
 type Seat {
   isOccupied: Boolean
   height: Int @range(min: 0, max: 100)
-  instanceTag: SeatPosition
+  seatPosition: SeatPosition @instanceTag
 }
 
 type Cabin @vspec(element: STRUCT) {

--- a/tests/test_jsonschema.py
+++ b/tests/test_jsonschema.py
@@ -2,7 +2,6 @@
 
 import json
 
-import pytest
 from graphql import build_schema
 
 from s2dm.exporters.jsonschema.jsonschema import transform
@@ -604,10 +603,10 @@ class TestAdvancedFeatures:
 
 
 class TestInstanceTagHandling:
-    def test_instance_tag_objects_excluded_from_schema(self) -> None:
-        """Test that objects with @instanceTag directive are excluded from JSON Schema."""
+    def test_instance_tag_objects_are_included_in_schema(self) -> None:
+        """Test that @instanceTag object types are emitted like normal object types."""
         schema_str = """
-            directive @instanceTag on OBJECT
+            directive @instanceTag on OBJECT | FIELD_DEFINITION
 
             type Query {
                 vehicle: Vehicle
@@ -647,12 +646,12 @@ class TestInstanceTagHandling:
         assert "RowEnum" in schema["$defs"]
         assert "ColumnEnum" in schema["$defs"]
 
-        assert "SeatPosition" not in schema["$defs"]
+        assert "SeatPosition" in schema["$defs"]
 
-    def test_error_on_invalid_instance_tag_field_name(self) -> None:
-        """Test that an error is raised if an instanceTag object is referenced incorrectly."""
+    def test_instance_tag_directive_allows_non_literal_field_name(self) -> None:
+        """Test that a field-level @instanceTag works on any field name."""
         schema_str = """
-            directive @instanceTag on OBJECT
+            directive @instanceTag on OBJECT | FIELD_DEFINITION
 
             type Query {
                 vehicle: Vehicle
@@ -660,7 +659,7 @@ class TestInstanceTagHandling:
 
             type Vehicle {
                 id: ID!
-                seatPosition: SeatPosition!
+                seatPosition: SeatPosition! @instanceTag
             }
 
             type SeatPosition @instanceTag {
@@ -680,15 +679,19 @@ class TestInstanceTagHandling:
         """
         graphql_schema = build_schema(schema_str)
 
-        with pytest.raises(
-            ValueError, match="Invalid schema: instanceTag object found on non-instanceTag named field 'seatPosition'"
-        ):
-            transform(graphql_schema)
+        result = transform(graphql_schema)
+        schema = json.loads(result)
 
-    def test_instance_tag_field_excluded_when_valid(self) -> None:
-        """Test that instanceTag fields are excluded when they reference valid instance tag objects."""
+        vehicle_def = schema["$defs"]["Vehicle"]
+        properties = vehicle_def["properties"]
+
+        assert properties["seatPosition"]["$ref"] == "#/$defs/SeatPosition"
+        assert schema["$defs"]["SeatPosition"]["type"] == "object"
+
+    def test_instance_tag_field_is_included_when_valid(self) -> None:
+        """Test that a valid field-level @instanceTag is emitted like a normal object field."""
         schema_str = """
-            directive @instanceTag on OBJECT
+            directive @instanceTag on OBJECT | FIELD_DEFINITION
 
             type Query {
                 vehicle: Vehicle
@@ -696,7 +699,7 @@ class TestInstanceTagHandling:
 
             type Vehicle {
                 id: ID!
-                instanceTag: CabinPosition!
+                cabinPosition: CabinPosition! @instanceTag
                 normalField: String!
             }
 
@@ -719,15 +722,12 @@ class TestInstanceTagHandling:
         result = transform(graphql_schema)
         schema = json.loads(result)
 
-        assert "Vehicle" in schema["$defs"]
         vehicle_def = schema["$defs"]["Vehicle"]
+        properties = vehicle_def["properties"]
 
-        assert "instanceTag" not in vehicle_def["properties"]
-
-        assert "id" in vehicle_def["properties"]
-        assert "normalField" in vehicle_def["properties"]
-
-        assert "CabinPosition" not in schema["$defs"]
+        assert properties["cabinPosition"]["$ref"] == "#/$defs/CabinPosition"
+        assert properties["normalField"]["type"] == "string"
+        assert schema["$defs"]["CabinPosition"]["type"] == "object"
 
     def test_instance_tag_field_included_when_invalid(self) -> None:
         """Test that instanceTag fields are included when they don't reference valid instance tag objects."""
@@ -738,7 +738,7 @@ class TestInstanceTagHandling:
 
             type Vehicle {
                 id: ID!
-                instanceTag: String!  # Not a valid instance tag object
+                tag: String!
                 normalField: String!
             }
         """
@@ -746,19 +746,16 @@ class TestInstanceTagHandling:
         result = transform(graphql_schema)
         schema = json.loads(result)
 
-        assert "Vehicle" in schema["$defs"]
         vehicle_def = schema["$defs"]["Vehicle"]
+        properties = vehicle_def["properties"]
 
-        assert "instanceTag" in vehicle_def["properties"]
-        assert vehicle_def["properties"]["instanceTag"]["type"] == "string"
-
-        assert "id" in vehicle_def["properties"]
-        assert "normalField" in vehicle_def["properties"]
+        assert properties["tag"]["type"] == "string"
+        assert properties["normalField"]["type"] == "string"
 
     def test_instance_tag_field_with_non_instance_tag_object(self) -> None:
         """Test that instanceTag fields referencing regular objects (without @instanceTag) are included."""
         schema_str = """
-            directive @instanceTag on OBJECT
+            directive @instanceTag on OBJECT | FIELD_DEFINITION
 
             type Query {
                 vehicle: Vehicle
@@ -766,7 +763,7 @@ class TestInstanceTagHandling:
 
             type Vehicle {
                 id: ID!
-                instanceTag: RegularObject!  # References object without @instanceTag
+                tag: RegularObject!
                 normalField: String!
             }
 
@@ -779,16 +776,12 @@ class TestInstanceTagHandling:
         result = transform(graphql_schema)
         schema = json.loads(result)
 
-        assert "Vehicle" in schema["$defs"]
         vehicle_def = schema["$defs"]["Vehicle"]
+        properties = vehicle_def["properties"]
 
-        assert "instanceTag" in vehicle_def["properties"]
-        assert vehicle_def["properties"]["instanceTag"]["$ref"] == "#/$defs/RegularObject"
-
-        assert "RegularObject" in schema["$defs"]
-
-        assert "id" in vehicle_def["properties"]
-        assert "normalField" in vehicle_def["properties"]
+        assert properties["tag"]["$ref"] == "#/$defs/RegularObject"
+        assert schema["$defs"]["RegularObject"]["type"] == "object"
+        assert properties["normalField"]["type"] == "string"
 
 
 class TestStrictMode:

--- a/tests/test_jsonschema.py
+++ b/tests/test_jsonschema.py
@@ -606,7 +606,7 @@ class TestInstanceTagHandling:
     def test_instance_tag_objects_are_included_in_schema(self) -> None:
         """Test that @instanceTag object types are emitted like normal object types."""
         schema_str = """
-            directive @instanceTag on OBJECT | FIELD_DEFINITION
+            directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM
 
             type Query {
                 vehicle: Vehicle
@@ -651,7 +651,7 @@ class TestInstanceTagHandling:
     def test_instance_tag_directive_allows_non_literal_field_name(self) -> None:
         """Test that a field-level @instanceTag works on any field name."""
         schema_str = """
-            directive @instanceTag on OBJECT | FIELD_DEFINITION
+            directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM
 
             type Query {
                 vehicle: Vehicle
@@ -691,7 +691,7 @@ class TestInstanceTagHandling:
     def test_instance_tag_field_is_included_when_valid(self) -> None:
         """Test that a valid field-level @instanceTag is emitted like a normal object field."""
         schema_str = """
-            directive @instanceTag on OBJECT | FIELD_DEFINITION
+            directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM
 
             type Query {
                 vehicle: Vehicle
@@ -755,7 +755,7 @@ class TestInstanceTagHandling:
     def test_instance_tag_field_with_non_instance_tag_object(self) -> None:
         """Test that instanceTag fields referencing regular objects (without @instanceTag) are included."""
         schema_str = """
-            directive @instanceTag on OBJECT | FIELD_DEFINITION
+            directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM
 
             type Query {
                 vehicle: Vehicle

--- a/tests/test_naming_utils.py
+++ b/tests/test_naming_utils.py
@@ -194,7 +194,7 @@ class TestApplyNamingToSchema:
     def test_apply_naming_routes_instancetag_enums_to_instancetag_case(self) -> None:
         """Enums inside @instanceTag types get instanceTag case; other enums get enumValue case."""
         schema = build_schema("""
-            directive @instanceTag on OBJECT | FIELD_DEFINITION
+            directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM
             type Query { car: Car }
             type Car { kind: CarKind }
             enum TwoRows { front rear }
@@ -230,7 +230,7 @@ class TestApplyNamingToSchema:
     def test_apply_naming_routes_directly_tagged_enum_to_instancetag_case(self) -> None:
         """Enums tagged with @instanceTag directly get instanceTag case."""
         schema = build_schema("""
-            directive @instanceTag on OBJECT | FIELD_DEFINITION | ENUM
+            directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM | ENUM
             type Query { door: Door }
             type Door { state: DoorState @instanceTag }
             enum DoorState @instanceTag { front_left front_right }
@@ -395,7 +395,7 @@ class TestInstanceTagConversion:
 
     def test_expand_instances_exclude_matches_schema_literals_with_instance_tag_naming(self) -> None:
         schema = build_schema("""
-        directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION
+        directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM
 
         enum RowEnum { ROW1 ROW2 }
         enum SideEnum { LEFT RIGHT }

--- a/tests/test_naming_utils.py
+++ b/tests/test_naming_utils.py
@@ -196,7 +196,7 @@ class TestApplyNamingToSchema:
         from graphql import build_schema as _build_schema
 
         schema = _build_schema("""
-            directive @instanceTag on OBJECT
+            directive @instanceTag on OBJECT | FIELD_DEFINITION
             type Query { car: Car }
             type Car { kind: CarKind }
             enum TwoRows { front rear }
@@ -301,27 +301,6 @@ class TestConvertFieldNames:
         convert_field_names(object_type, NamingConventionConfig(), schema)
 
         assert "TestField" in object_type.fields
-
-    def test_skip_instance_tag_field_conversion(self, spec_directory: Path) -> None:
-        """Test that instanceTag fields pointing to @instanceTag types are not converted."""
-        schema_path = Path(__file__).parent / "test_expanded_instances" / "test_schema.graphql"
-        schema = load_schema([spec_directory, schema_path])
-
-        door_type = schema.get_type("Door")
-        assert isinstance(door_type, GraphQLObjectType)
-
-        door_type.fields["regularField"] = GraphQLField(GraphQLString)
-
-        naming_config = NamingConventionConfig(field=FieldNamingConfig(object=CaseFormat.CAMEL_CASE))
-        convert_field_names(door_type, naming_config, schema)
-
-        assert "instanceTag" in door_type.fields
-        assert "instancetag" not in door_type.fields
-
-        assert "regularField" in door_type.fields
-        assert "RegularField" not in door_type.fields
-
-        assert "isLocked" in door_type.fields  # was "isLocked" -> should stay as is in camelCase
 
 
 class TestConvertEnumValues:

--- a/tests/test_naming_utils.py
+++ b/tests/test_naming_utils.py
@@ -12,11 +12,11 @@ from graphql import (
     GraphQLObjectType,
     GraphQLSchema,
     GraphQLString,
+    build_schema,
 )
 
 from s2dm.exporters.shacl import translate_to_shacl
-from s2dm.exporters.utils.extraction import get_all_object_types, get_all_objects_with_directive
-from s2dm.exporters.utils.instance_tag import expand_instance_tag, expand_instances_in_schema
+from s2dm.exporters.utils.instance_tag import expand_instances_in_schema
 from s2dm.exporters.utils.naming import (
     apply_naming_to_schema,
     convert_enum_values,
@@ -193,9 +193,7 @@ class TestApplyNamingToSchema:
 
     def test_apply_naming_routes_instancetag_enums_to_instancetag_case(self) -> None:
         """Enums inside @instanceTag types get instanceTag case; other enums get enumValue case."""
-        from graphql import build_schema as _build_schema
-
-        schema = _build_schema("""
+        schema = build_schema("""
             directive @instanceTag on OBJECT | FIELD_DEFINITION
             type Query { car: Car }
             type Car { kind: CarKind }
@@ -228,6 +226,32 @@ class TestApplyNamingToSchema:
         assert "SEDAN" in car_kind.values
         assert "SUV" in car_kind.values
         assert "sedan" not in car_kind.values
+
+    def test_apply_naming_routes_directly_tagged_enum_to_instancetag_case(self) -> None:
+        """Enums tagged with @instanceTag directly get instanceTag case."""
+        schema = build_schema("""
+            directive @instanceTag on OBJECT | FIELD_DEFINITION | ENUM
+            type Query { door: Door }
+            type Door { state: DoorState @instanceTag }
+            enum DoorState @instanceTag { front_left front_right }
+            enum CarKind { sedan suv }
+        """)
+        naming_config = NamingConventionConfig(
+            enum_value=CaseFormat.MACRO_CASE,
+            instance_tag=CaseFormat.PASCAL_CASE,
+        )
+        apply_naming_to_schema(schema, naming_config)
+
+        door_state = schema.get_type("DoorState")
+        assert isinstance(door_state, GraphQLEnumType)
+        assert "FrontLeft" in door_state.values
+        assert "FrontRight" in door_state.values
+        assert "front_left" not in door_state.values
+
+        car_kind = schema.get_type("CarKind")
+        assert isinstance(car_kind, GraphQLEnumType)
+        assert "SEDAN" in car_kind.values
+        assert "SUV" in car_kind.values
 
 
 class TestConvertFieldNames:
@@ -347,38 +371,6 @@ class TestConvertEnumValues:
 class TestInstanceTagConversion:
     """Test instance tag expansion with naming conversion."""
 
-    def test_expand_instance_tag_with_naming_config(self, spec_directory: Path) -> None:
-        """Test that instance tag expansion applies naming conversion."""
-        schema_path = Path(__file__).parent / "test_expanded_instances" / "test_schema.graphql"
-        schema = load_schema([spec_directory, schema_path])
-        object_types = get_all_object_types(schema)
-        instance_tag_objects = get_all_objects_with_directive(object_types, "instanceTag")
-
-        assert len(instance_tag_objects) > 0
-        door_position = next((obj for obj in instance_tag_objects if obj.name == "DoorPosition"), None)
-        assert door_position is not None
-
-        naming_config = NamingConventionConfig(instance_tag=CaseFormat.PASCAL_CASE)
-        result = expand_instance_tag(door_position, naming_config)
-
-        expected = ["Row1.Driverside", "Row1.Passengerside", "Row2.Driverside", "Row2.Passengerside"]
-        assert set(result) == set(expected)
-
-    def test_expand_instance_tag_without_naming_config(self, spec_directory: Path) -> None:
-        """Test that instance tag expansion works without naming config."""
-        schema_path = Path(__file__).parent / "test_expanded_instances" / "test_schema.graphql"
-        schema = load_schema([spec_directory, schema_path])
-        object_types = get_all_object_types(schema)
-        instance_tag_objects = get_all_objects_with_directive(object_types, "instanceTag")
-
-        door_position = next((obj for obj in instance_tag_objects if obj.name == "DoorPosition"), None)
-        assert door_position is not None
-
-        result = expand_instance_tag(door_position)
-
-        expected = ["ROW1.DRIVERSIDE", "ROW1.PASSENGERSIDE", "ROW2.DRIVERSIDE", "ROW2.PASSENGERSIDE"]
-        assert set(result) == set(expected)
-
     def test_expand_instances_in_schema_pipeline_applies_instance_tag_case(self, spec_directory: Path) -> None:
         """Full pipeline: expand_instances_in_schema applies instanceTag case to resolved_names."""
         schema_path = Path(__file__).parent / "test_expanded_instances" / "test_schema.graphql"
@@ -400,6 +392,40 @@ class TestInstanceTagConversion:
             "Door.Row2.Driverside",
             "Door.Row2.Passengerside",
         }
+
+    def test_expand_instances_exclude_matches_schema_literals_with_instance_tag_naming(self) -> None:
+        schema = build_schema("""
+        directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION
+
+        enum RowEnum { ROW1 ROW2 }
+        enum SideEnum { LEFT RIGHT }
+
+        type DoorPosition @instanceTag {
+          row: RowEnum!
+          side: SideEnum!
+        }
+
+        type Door {
+          doorPosition: DoorPosition @instanceTag(exclude: [\"ROW1.LEFT\"])
+        }
+
+        type Cabin {
+          doors: [Door]
+        }
+
+        type Query {
+          cabin: Cabin
+        }
+        """)
+
+        naming_config = NamingConventionConfig(instance_tag=CaseFormat.PASCAL_CASE)
+
+        apply_naming_to_schema(schema, naming_config)
+        _, _, field_metadata = expand_instances_in_schema(schema, naming_config)
+
+        door_meta = field_metadata.get(("Cabin", "Door"))
+        assert door_meta is not None
+        assert door_meta.resolved_names == ["Door.Row1.Right", "Door.Row2.Left", "Door.Row2.Right"]
 
     def test_shacl_instancetag_nodeshape_uses_instance_tag_case(self, spec_directory: Path) -> None:
         """translate_to_shacl applies instanceTag naming to sh:in values inside @instanceTag NodeShapes."""

--- a/tests/test_protobuf.py
+++ b/tests/test_protobuf.py
@@ -525,8 +525,8 @@ class TestProtobufExporter:
         """Test that types with @instanceTag directive are included when expansion is disabled."""
         graphql_schema = load_schema_with_naming(test_schema_path, None)
         selection_query = parse(
-            "query Selection { cabin { seats { isOccupied height instanceTag { row position } } "
-            "doors { isLocked position instanceTag { row side } } temperature } }"
+            "query Selection { cabin { seats { isOccupied height seatPosition { row position } } "
+            "doors { isLocked position doorPosition { row side } } temperature } }"
         )
         annotated_schema = process_schema(schema=graphql_schema, source_map={}, query_document=selection_query)
         result = translate_to_protobuf(annotated_schema, selection_query=selection_query)
@@ -556,7 +556,7 @@ class TestProtobufExporter:
             r'option \(message_source\) = "Seat".*?;.*?'
             r"bool isOccupied = 1.*?;.*?"
             r"int32 height = 2.*?"
-            r"SeatPosition instanceTag = 3.*?;.*?"
+            r"SeatPosition seatPosition = 3.*?;.*?"
             r"\}",
             result,
             re.DOTALL,
@@ -567,7 +567,7 @@ class TestProtobufExporter:
             r'option \(message_source\) = "Door".*?;.*?'
             r"bool isLocked = 1.*?;.*?"
             r"int32 position = 2.*?"
-            r"DoorPosition instanceTag = 3.*?;.*?"
+            r"DoorPosition doorPosition = 3.*?;.*?"
             r"\}",
             result,
             re.DOTALL,
@@ -766,7 +766,7 @@ class TestProtobufExporter:
         """Test that flatten mode includes types referenced by non-flattened types and their dependencies."""
         graphql_schema = load_schema_with_naming(test_schema_path, None)
         selection_query = parse(
-            "query Selection { vehicle { doors { isLocked position instanceTag { row side } } model year features } }"
+            "query Selection { vehicle { doors { isLocked position doorPosition { row side } } model year features } }"
         )
         annotated_schema = process_schema(schema=graphql_schema, source_map={}, query_document=selection_query)
         result = translate_to_protobuf(
@@ -790,7 +790,7 @@ class TestProtobufExporter:
             r'option \(message_source\) = "Door";.*?'
             r"optional bool isLocked = 1;.*?"
             r"optional int32 position = 2 \[\(buf\.validate\.field\)\.int32 = \{gte: 0, lte: 100\}\];.*?"
-            r"optional DoorPosition instanceTag = 3;.*?"
+            r"optional DoorPosition doorPosition = 3;.*?"
             r"\}",
             result,
             re.DOTALL,
@@ -932,7 +932,7 @@ class TestProtobufExporter:
             door {
                 isLocked
                 position
-                instanceTag { row side }
+                doorPosition { row side }
             }
         }
         """
@@ -956,9 +956,9 @@ class TestProtobufExporter:
             r'optional bool Door_isLocked = 5 \[\(field_source\) = "Door"\];.*?'
             r'optional int32 Door_position = 6 \[\(field_source\) = "Door", '
             r"\(buf\.validate\.field\)\.int32 = \{gte: 0, lte: 100\}\];.*?"
-            r'RowEnum\.Enum Door_instanceTag_row = 7 \[\(field_source\) = "DoorPosition", '
+            r'RowEnum\.Enum Door_doorPosition_row = 7 \[\(field_source\) = "DoorPosition", '
             r"\(buf\.validate\.field\)\.required = true\];.*?"
-            r'SideEnum\.Enum Door_instanceTag_side = 8 \[\(field_source\) = "DoorPosition", '
+            r'SideEnum\.Enum Door_doorPosition_side = 8 \[\(field_source\) = "DoorPosition", '
             r"\(buf\.validate\.field\)\.required = true\];.*?"
             r"\}",
             result,
@@ -1037,7 +1037,7 @@ class TestProtobufExporter:
             door {
                 isLocked
                 position
-                instanceTag { row side }
+                doorPosition { row side }
             }
         }
         """
@@ -1059,9 +1059,9 @@ class TestProtobufExporter:
             r'optional bool Door_isLocked = 5 \[\(field_source\) = "Door"\];.*?'
             r'optional int32 Door_position = 6 \[\(field_source\) = "Door", '
             r"\(buf\.validate\.field\)\.int32 = \{gte: 0, lte: 100\}\];.*?"
-            r'RowEnum\.Enum Door_instanceTag_row = 7 \[\(field_source\) = "DoorPosition", '
+            r'RowEnum\.Enum Door_doorPosition_row = 7 \[\(field_source\) = "DoorPosition", '
             r"\(buf\.validate\.field\)\.required = true\];.*?"
-            r'SideEnum\.Enum Door_instanceTag_side = 8 \[\(field_source\) = "DoorPosition", '
+            r'SideEnum\.Enum Door_doorPosition_side = 8 \[\(field_source\) = "DoorPosition", '
             r"\(buf\.validate\.field\)\.required = true\];.*?"
             r"\}",
             result,

--- a/tests/test_rdf_materializer.py
+++ b/tests/test_rdf_materializer.py
@@ -40,7 +40,7 @@ def _subject(graph: Graph, rdf_type: Any, name_in: str, *, exclude: str | None =
 def _cabin_door_schema() -> GraphQLSchema:
     """Test Cabin/Door/Window schema."""
     return build_schema("""
-        directive @instanceTag on OBJECT | FIELD_DEFINITION
+        directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM
 
         type Query { cabin: Cabin }
 

--- a/tests/test_rdf_materializer.py
+++ b/tests/test_rdf_materializer.py
@@ -40,6 +40,8 @@ def _subject(graph: Graph, rdf_type: Any, name_in: str, *, exclude: str | None =
 def _cabin_door_schema() -> GraphQLSchema:
     """Test Cabin/Door/Window schema."""
     return build_schema("""
+        directive @instanceTag on OBJECT | FIELD_DEFINITION
+
         type Query { cabin: Cabin }
 
         type Cabin {
@@ -53,7 +55,7 @@ def _cabin_door_schema() -> GraphQLSchema:
         }
 
         type Door {
-            instanceTag: InCabinArea2x2
+            inCabinArea: InCabinArea2x2 @instanceTag
             isOpen: Boolean
             window: Window
         }
@@ -62,7 +64,7 @@ def _cabin_door_schema() -> GraphQLSchema:
             isTinted: Boolean
         }
 
-        type InCabinArea2x2 {
+        type InCabinArea2x2 @instanceTag {
             row: TwoRowsInCabinEnum
             column: TwoColumnsInCabinEnum
         }

--- a/tests/test_schema_loader.py
+++ b/tests/test_schema_loader.py
@@ -3,7 +3,12 @@ from pathlib import Path
 import pytest
 from graphql import DocumentNode, GraphQLObjectType, build_schema, parse
 
-from s2dm.exporters.utils.schema_loader import load_schema_with_source_map, print_schema_with_directives_preserved
+from s2dm.exporters.utils.schema_loader import (
+    check_correct_schema,
+    load_schema_with_source_map,
+    print_schema_with_directives_preserved,
+)
+from s2dm.exporters.utils.violations import ConstraintCode
 
 
 @pytest.fixture
@@ -302,3 +307,44 @@ def test_compose_preserves_directive_with_various_scalar_types() -> None:
     assert "enabled: true" in result
     # Ensure enums are not quoted
     assert "status: ACTIVE" in result
+
+
+def test_check_correct_schema_flags_multiple_instance_tag_fields() -> None:
+    schema_str = """
+    directive @instanceTag on OBJECT | FIELD_DEFINITION
+
+    type TagObj @instanceTag {
+      level: TagEnum
+    }
+    enum TagEnum { A B }
+
+    type Foo {
+      tag1: TagObj @instanceTag
+      tag2: TagObj @instanceTag
+    }
+
+    type Query { foo: Foo }
+    """
+    schema = build_schema(schema_str)
+    codes = [violation.code for violation in check_correct_schema(schema)]
+    assert ConstraintCode.INSTANCE_TAG_MULTIPLE_FIELDS in codes
+
+
+def test_check_correct_schema_allows_single_instance_tag_field() -> None:
+    schema_str = """
+    directive @instanceTag on OBJECT | FIELD_DEFINITION
+
+    type TagObj @instanceTag {
+      level: TagEnum
+    }
+    enum TagEnum { A B }
+
+    type Foo {
+      tag: TagObj @instanceTag
+    }
+
+    type Query { foo: Foo }
+    """
+    schema = build_schema(schema_str)
+    codes = [violation.code for violation in check_correct_schema(schema)]
+    assert ConstraintCode.INSTANCE_TAG_MULTIPLE_FIELDS not in codes

--- a/tests/test_schema_loader.py
+++ b/tests/test_schema_loader.py
@@ -8,7 +8,7 @@ from s2dm.exporters.utils.schema_loader import (
     load_schema_with_source_map,
     print_schema_with_directives_preserved,
 )
-from s2dm.exporters.utils.violations import ConstraintCode
+from s2dm.exporters.utils.violations import ConstraintCode, Severity
 
 
 @pytest.fixture
@@ -313,17 +313,17 @@ def test_check_correct_schema_flags_multiple_instance_tag_fields() -> None:
     schema_str = """
     directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM
 
-    type TagObj @instanceTag {
-      level: TagEnum
+    type SeatPosition @instanceTag {
+      level: HeightLevel
     }
-    enum TagEnum { A B }
+    enum HeightLevel { LOW HIGH }
 
-    type Foo {
-      tag1: TagObj @instanceTag
-      tag2: TagObj @instanceTag
+    type Vehicle {
+      position: SeatPosition @instanceTag
+      trim: SeatPosition @instanceTag
     }
 
-    type Query { foo: Foo }
+    type Query { vehicle: Vehicle }
     """
     schema = build_schema(schema_str)
     codes = [violation.code for violation in check_correct_schema(schema)]
@@ -334,17 +334,61 @@ def test_check_correct_schema_allows_single_instance_tag_field() -> None:
     schema_str = """
     directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM
 
-    type TagObj @instanceTag {
-      level: TagEnum
+    type SeatPosition @instanceTag {
+      level: HeightLevel
     }
-    enum TagEnum { A B }
+    enum HeightLevel { LOW HIGH }
 
-    type Foo {
-      tag: TagObj @instanceTag
+    type Vehicle {
+      position: SeatPosition @instanceTag
     }
 
-    type Query { foo: Foo }
+    type Query { vehicle: Vehicle }
     """
     schema = build_schema(schema_str)
     codes = [violation.code for violation in check_correct_schema(schema)]
     assert ConstraintCode.INSTANCE_TAG_MULTIPLE_FIELDS not in codes
+
+
+def test_check_correct_schema_includes_instance_tag_rule_violations() -> None:
+    schema_str = """
+    directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM
+
+    type EngineSpecs {
+      power: String
+    }
+
+    type Vehicle {
+      engine: EngineSpecs @instanceTag
+    }
+
+    type Query { vehicle: Vehicle }
+    """
+    schema = build_schema(schema_str)
+    codes = [violation.code for violation in check_correct_schema(schema)]
+    assert ConstraintCode.INSTANCE_TAG_INVALID_REFERENCE in codes
+
+
+def test_check_correct_schema_excludes_warning_severity_violations() -> None:
+    schema_str = """
+    directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM
+
+    type SeatPosition @instanceTag {
+      level: HeightLevel
+    }
+    enum HeightLevel { LOW HIGH }
+
+    type Door {
+      position: SeatPosition @instanceTag
+      isLocked: Boolean
+    }
+
+    type Cabin {
+      door: Door
+    }
+
+    type Query { cabin: Cabin }
+    """
+    schema = build_schema(schema_str)
+    violations = check_correct_schema(schema)
+    assert all(violation.severity == Severity.ERROR for violation in violations)

--- a/tests/test_schema_loader.py
+++ b/tests/test_schema_loader.py
@@ -311,7 +311,7 @@ def test_compose_preserves_directive_with_various_scalar_types() -> None:
 
 def test_check_correct_schema_flags_multiple_instance_tag_fields() -> None:
     schema_str = """
-    directive @instanceTag on OBJECT | FIELD_DEFINITION
+    directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM
 
     type TagObj @instanceTag {
       level: TagEnum
@@ -332,7 +332,7 @@ def test_check_correct_schema_flags_multiple_instance_tag_fields() -> None:
 
 def test_check_correct_schema_allows_single_instance_tag_field() -> None:
     schema_str = """
-    directive @instanceTag on OBJECT | FIELD_DEFINITION
+    directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM
 
     type TagObj @instanceTag {
       level: TagEnum

--- a/tests/test_schema_processing.py
+++ b/tests/test_schema_processing.py
@@ -92,6 +92,92 @@ class TestLoadAndProcessSchema:
         assert "Seat" in cabin_type.fields
         assert "seats" not in cabin_type.fields
 
+    def test_load_with_expanded_instances_uses_enum_values_without_tag_field_wrapper(
+        self, enum_instance_tag_schema_path: Path
+    ) -> None:
+        annotated_schema, _, _ = load_and_process_schema(
+            [enum_instance_tag_schema_path], None, None, None, expanded_instances=True
+        )
+
+        vehicle_type = cast(GraphQLObjectType, annotated_schema.schema.type_map["Vehicle"])
+        assert "Mirror" in vehicle_type.fields
+        assert "mirrors" not in vehicle_type.fields
+
+        mirror_branch_type = cast(GraphQLObjectType, annotated_schema.schema.type_map["Mirror_Position"])
+        assert "LEFT" in mirror_branch_type.fields
+        assert "CENTER" in mirror_branch_type.fields
+        assert "RIGHT" in mirror_branch_type.fields
+        assert "position" not in mirror_branch_type.fields
+
+        mirror_type = cast(GraphQLObjectType, annotated_schema.schema.type_map["Mirror"])
+        assert "isFolded" in mirror_type.fields
+        assert "position" not in mirror_type.fields
+
+        field_meta = annotated_schema.field_metadata[("Vehicle", "Mirror")]
+        assert field_meta.resolved_names == ["Mirror.LEFT", "Mirror.CENTER", "Mirror.RIGHT"]
+
+    def test_load_with_expanded_instances_prunes_excluded_instance_tag_combination(self, tmp_path: Path) -> None:
+        schema_path = tmp_path / "excluded_instance.graphql"
+        schema_path.write_text("""
+        directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION
+
+        enum RowEnum { ROW1 ROW2 }
+        enum SideEnum { LEFT RIGHT }
+
+        type DoorPosition @instanceTag {
+          row: RowEnum!
+          side: SideEnum!
+        }
+
+        type Door {
+          isLocked: Boolean
+          doorPosition: DoorPosition @instanceTag(exclude: [\"ROW1.LEFT\"])
+        }
+
+        type Cabin {
+          doors: [Door]
+        }
+
+        type Query {
+          cabin: Cabin
+        }
+        """)
+
+        annotated_schema, _, _ = load_and_process_schema([schema_path], None, None, None, expanded_instances=True)
+
+        field_meta = annotated_schema.field_metadata[("Cabin", "Door")]
+
+        assert field_meta.resolved_names == ["Door.ROW1.RIGHT", "Door.ROW2.LEFT", "Door.ROW2.RIGHT"]
+
+    def test_load_with_expanded_instances_raises_when_exclude_list_matches_nothing(self, tmp_path: Path) -> None:
+        schema_path = tmp_path / "invalid_excluded_instance.graphql"
+        schema_path.write_text("""
+        directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION
+
+        enum RowEnum { ROW1 ROW2 }
+        enum SideEnum { LEFT RIGHT }
+
+        type DoorPosition @instanceTag {
+          row: RowEnum!
+          side: SideEnum!
+        }
+
+        type Door {
+          doorPosition: DoorPosition @instanceTag(exclude: [\"ROW9.LEFT\"])
+        }
+
+        type Cabin {
+          doors: [Door]
+        }
+
+        type Query {
+          cabin: Cabin
+        }
+        """)
+
+        with pytest.raises(ValueError):
+            load_and_process_schema([schema_path], None, None, None, expanded_instances=True)
+
     def test_load_with_naming_config(self, schema_path: list[Path], naming_config_path: Path) -> None:
         annotated_schema, naming_config, query_document = load_and_process_schema(
             schema_path, naming_config_path, None, None, False

--- a/tests/test_schema_processing.py
+++ b/tests/test_schema_processing.py
@@ -178,6 +178,46 @@ class TestLoadAndProcessSchema:
         with pytest.raises(ValueError):
             load_and_process_schema([schema_path], None, None, None, expanded_instances=True)
 
+    def test_load_with_expanded_instances_does_not_expand_non_list_field(self, tmp_path: Path) -> None:
+        schema_path = tmp_path / "non_list_instance_tag.graphql"
+        schema_path.write_text("""
+        directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM
+
+        enum RowEnum { ROW1 ROW2 }
+        enum SideEnum { LEFT RIGHT }
+
+        type DoorPosition @instanceTag {
+          row: RowEnum!
+          side: SideEnum!
+        }
+
+        type Door {
+          isLocked: Boolean
+          doorPosition: DoorPosition @instanceTag
+        }
+
+        type Cabin {
+          door: Door
+        }
+
+        type Query {
+          cabin: Cabin
+        }
+        """)
+
+        annotated_schema, _, _ = load_and_process_schema([schema_path], None, None, None, expanded_instances=True)
+
+        assert "Door_Row" not in annotated_schema.schema.type_map
+        assert "Door_Side" not in annotated_schema.schema.type_map
+
+        cabin_type = cast(GraphQLObjectType, annotated_schema.schema.type_map["Cabin"])
+        assert "door" in cabin_type.fields
+        assert "Door" not in cabin_type.fields
+
+        door_type = cast(GraphQLObjectType, annotated_schema.schema.type_map["Door"])
+        assert "doorPosition" in door_type.fields
+        assert "DoorPosition" in annotated_schema.schema.type_map
+
     def test_load_with_naming_config(self, schema_path: list[Path], naming_config_path: Path) -> None:
         annotated_schema, naming_config, query_document = load_and_process_schema(
             schema_path, naming_config_path, None, None, False

--- a/tests/test_schema_processing.py
+++ b/tests/test_schema_processing.py
@@ -119,7 +119,7 @@ class TestLoadAndProcessSchema:
     def test_load_with_expanded_instances_prunes_excluded_instance_tag_combination(self, tmp_path: Path) -> None:
         schema_path = tmp_path / "excluded_instance.graphql"
         schema_path.write_text("""
-        directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION
+        directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM
 
         enum RowEnum { ROW1 ROW2 }
         enum SideEnum { LEFT RIGHT }
@@ -152,7 +152,7 @@ class TestLoadAndProcessSchema:
     def test_load_with_expanded_instances_raises_when_exclude_list_matches_nothing(self, tmp_path: Path) -> None:
         schema_path = tmp_path / "invalid_excluded_instance.graphql"
         schema_path.write_text("""
-        directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION
+        directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM
 
         enum RowEnum { ROW1 ROW2 }
         enum SideEnum { LEFT RIGHT }

--- a/tests/test_type_modifiers/test_spec.graphql
+++ b/tests/test_type_modifiers/test_spec.graphql
@@ -82,7 +82,7 @@ enum SomeEnum {
 }
 
 type ExampleTypeWithInstances {
-    instanceTag: ExampleTypeInstance
+    exampleType: ExampleTypeInstance @instanceTag
     anotherField: Boolean
 }
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -513,6 +513,120 @@ def test_expand_instances_with_exclusion_on_flat_enum_instance() -> None:
     ]
 
 
+def test_expand_instances_honors_exclusion_on_source_types() -> None:
+    """An exclude on the source object or enum type is applied even when the field carries none."""
+    schema = build_schema("""
+        directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM
+
+        enum RowEnum {
+            ROW1
+            ROW2
+        }
+
+        enum SideEnum {
+            LEFT
+            RIGHT
+        }
+
+        type DoorPosition @instanceTag(exclude: ["ROW1.LEFT"]) {
+            row: RowEnum!
+            side: SideEnum!
+        }
+
+        enum MirrorPosition @instanceTag(exclude: ["CENTER"]) {
+            LEFT
+            CENTER
+            RIGHT
+        }
+
+        type Door {
+            doorPosition: DoorPosition @instanceTag
+        }
+
+        type Mirror {
+            position: MirrorPosition @instanceTag
+        }
+
+        type Cabin {
+            doors: [Door]
+            mirrors: [Mirror]
+        }
+    """)
+
+    expanded_schema, _, field_metadata = instance_tag_utils.expand_instances_in_schema(schema)
+    type_map = expanded_schema.type_map
+
+    assert set(cast(GraphQLObjectType, type_map["Door_ROW1_Side"]).fields) == {"RIGHT"}
+    assert set(cast(GraphQLObjectType, type_map["Door_ROW2_Side"]).fields) == {"LEFT", "RIGHT"}
+    assert set(cast(GraphQLObjectType, type_map["Mirror_Position"]).fields) == {"LEFT", "RIGHT"}
+
+    assert field_metadata[("Cabin", "Door")].resolved_names == [
+        "Door.ROW1.RIGHT",
+        "Door.ROW2.LEFT",
+        "Door.ROW2.RIGHT",
+    ]
+    assert field_metadata[("Cabin", "Mirror")].resolved_names == [
+        "Mirror.LEFT",
+        "Mirror.RIGHT",
+    ]
+
+
+def test_expand_instances_merges_field_and_source_type_exclusions() -> None:
+    """Excludes on the field and on the source object/enum type are merged before expansion."""
+    schema = build_schema("""
+        directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM
+
+        enum RowEnum {
+            ROW1
+            ROW2
+        }
+
+        enum SideEnum {
+            LEFT
+            RIGHT
+        }
+
+        type DoorPosition @instanceTag(exclude: ["ROW1.LEFT"]) {
+            row: RowEnum!
+            side: SideEnum!
+        }
+
+        enum MirrorPosition @instanceTag(exclude: ["CENTER"]) {
+            LEFT
+            CENTER
+            RIGHT
+        }
+
+        type Door {
+            doorPosition: DoorPosition @instanceTag(exclude: ["ROW2.RIGHT"])
+        }
+
+        type Mirror {
+            position: MirrorPosition @instanceTag(exclude: ["LEFT"])
+        }
+
+        type Cabin {
+            doors: [Door]
+            mirrors: [Mirror]
+        }
+    """)
+
+    expanded_schema, _, field_metadata = instance_tag_utils.expand_instances_in_schema(schema)
+    type_map = expanded_schema.type_map
+
+    assert set(cast(GraphQLObjectType, type_map["Door_ROW1_Side"]).fields) == {"RIGHT"}
+    assert set(cast(GraphQLObjectType, type_map["Door_ROW2_Side"]).fields) == {"LEFT"}
+    assert set(cast(GraphQLObjectType, type_map["Mirror_Position"]).fields) == {"RIGHT"}
+
+    assert field_metadata[("Cabin", "Door")].resolved_names == [
+        "Door.ROW1.RIGHT",
+        "Door.ROW2.LEFT",
+    ]
+    assert field_metadata[("Cabin", "Mirror")].resolved_names == [
+        "Mirror.RIGHT",
+    ]
+
+
 # #########################################################
 # Directive utils
 # #########################################################

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -266,42 +266,6 @@ def test_get_all_objects_with_directive(schema_path: list[Path]) -> None:
 # #########################################################
 
 
-def test_expand_instance_tag_and_get_all_expanded_instance_tags(schema_path: list[Path]) -> None:
-    schema = schema_loader_utils.load_schema(schema_path)
-    tags: dict[GraphQLObjectType, list[str]] = instance_tag_utils.get_all_expanded_instance_tags(schema)
-    assert isinstance(tags, dict)
-
-
-def test_is_valid_instance_tag_field_and_has_valid_instance_tag_field(schema_path: list[Path]) -> None:
-    schema = schema_loader_utils.load_schema(schema_path)
-    object_types = extraction_utils.get_all_object_types(schema)
-    for obj in object_types:
-        for field in obj.fields.values():
-            _ = instance_tag_utils.is_valid_instance_tag_field(field, schema)
-            break
-        break
-    for obj in object_types:
-        _ = instance_tag_utils.has_valid_instance_tag_field(obj, schema)
-        break
-
-
-def test_get_instance_tag_object_and_dict(schema_path: list[Path]) -> None:
-    schema = schema_loader_utils.load_schema(schema_path)
-    object_types = extraction_utils.get_all_object_types(schema)
-    for obj in object_types:
-        tag_obj = instance_tag_utils.get_instance_tag_object(obj, schema)
-        if tag_obj:
-            tag_dict: dict[str, list[str]] = instance_tag_utils.get_instance_tag_dict(tag_obj)
-            assert isinstance(tag_dict, dict)
-        break
-    for obj in object_types:
-        tag_obj = instance_tag_utils.get_instance_tag_object(obj, schema)
-        if tag_obj:
-            tag_dict = instance_tag_utils.get_instance_tag_dict(tag_obj)
-            assert isinstance(tag_dict, dict)
-        break
-
-
 def test_expand_instances_in_schema(spec_directory: Path) -> None:
     schema = schema_loader_utils.load_schema(
         [spec_directory, Path("tests/test_expanded_instances/test_schema.graphql")]
@@ -344,6 +308,211 @@ def test_expand_instances_in_schema(spec_directory: Path) -> None:
     assert "instanceTag" not in seat_type.fields
 
 
+def test_expand_instances_with_exclusion_diverges_intermediate_types() -> None:
+    """Excluding one combination splits the affected level into prefixed per-branch types."""
+    schema = build_schema("""
+        directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM
+
+        enum RowEnum {
+            ROW1
+            ROW2
+        }
+
+        enum SideEnum {
+            LEFT
+            RIGHT
+        }
+
+        type DoorPosition @instanceTag {
+            row: RowEnum!
+            side: SideEnum!
+        }
+
+        type Door {
+            doorPosition: DoorPosition @instanceTag(exclude: ["ROW1.LEFT"])
+        }
+
+        type Cabin {
+            doors: [Door]
+        }
+
+        type Query {
+            cabin: Cabin
+        }
+    """)
+
+    expanded_schema, _, field_metadata = instance_tag_utils.expand_instances_in_schema(schema)
+    type_map = expanded_schema.type_map
+
+    assert set(cast(GraphQLObjectType, type_map["Door_Row"]).fields) == {"ROW1", "ROW2"}
+    assert set(cast(GraphQLObjectType, type_map["Door_ROW1_Side"]).fields) == {"RIGHT"}
+    assert set(cast(GraphQLObjectType, type_map["Door_ROW2_Side"]).fields) == {"LEFT", "RIGHT"}
+    assert "Door_Side" not in type_map
+
+    assert field_metadata[("Cabin", "Door")].resolved_names == [
+        "Door.ROW1.RIGHT",
+        "Door.ROW2.LEFT",
+        "Door.ROW2.RIGHT",
+    ]
+
+
+def test_expand_instances_with_exclusion_across_multiple_dimensions() -> None:
+    """With three dimensions, only branches touched by the exclusion diverge; the rest stay shared."""
+    schema = build_schema("""
+        directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM
+
+        enum RowEnum {
+            ROW1
+            ROW2
+        }
+
+        enum SideEnum {
+            LEFT
+            RIGHT
+        }
+
+        enum HeightEnum {
+            TOP
+            BOTTOM
+        }
+
+        type DoorPosition @instanceTag {
+            row: RowEnum!
+            side: SideEnum!
+            height: HeightEnum!
+        }
+
+        type Door {
+            doorPosition: DoorPosition @instanceTag(exclude: ["ROW1.LEFT.TOP", "ROW2.RIGHT.BOTTOM"])
+        }
+
+        type Cabin {
+            doors: [Door]
+        }
+
+        type Query {
+            cabin: Cabin
+        }
+    """)
+
+    expanded_schema, _, field_metadata = instance_tag_utils.expand_instances_in_schema(schema)
+    type_map = expanded_schema.type_map
+
+    assert set(cast(GraphQLObjectType, type_map["Door_Row"]).fields) == {"ROW1", "ROW2"}
+    assert set(cast(GraphQLObjectType, type_map["Door_ROW1_Side"]).fields) == {"LEFT", "RIGHT"}
+    assert set(cast(GraphQLObjectType, type_map["Door_ROW2_Side"]).fields) == {"LEFT", "RIGHT"}
+    assert set(cast(GraphQLObjectType, type_map["Door_ROW1_LEFT_Height"]).fields) == {"BOTTOM"}
+    assert set(cast(GraphQLObjectType, type_map["Door_ROW1_RIGHT_Height"]).fields) == {"TOP", "BOTTOM"}
+    assert set(cast(GraphQLObjectType, type_map["Door_ROW2_LEFT_Height"]).fields) == {"TOP", "BOTTOM"}
+    assert set(cast(GraphQLObjectType, type_map["Door_ROW2_RIGHT_Height"]).fields) == {"TOP"}
+    assert "Door_Height" not in type_map
+
+    assert field_metadata[("Cabin", "Door")].resolved_names == [
+        "Door.ROW1.LEFT.BOTTOM",
+        "Door.ROW1.RIGHT.TOP",
+        "Door.ROW1.RIGHT.BOTTOM",
+        "Door.ROW2.LEFT.TOP",
+        "Door.ROW2.LEFT.BOTTOM",
+        "Door.ROW2.RIGHT.TOP",
+    ]
+
+
+def test_expand_instances_multiple_dimensions_share_level_types_without_exclusion() -> None:
+    """Without exclusion, every level collapses to a single shared type across all three dimensions."""
+    schema = build_schema("""
+        directive @instanceTag on OBJECT | FIELD_DEFINITION
+
+        enum RowEnum {
+            ROW1
+            ROW2
+        }
+
+        enum SideEnum {
+            LEFT
+            RIGHT
+        }
+
+        enum HeightEnum {
+            TOP
+            BOTTOM
+        }
+
+        type DoorPosition @instanceTag {
+            row: RowEnum!
+            side: SideEnum!
+            height: HeightEnum!
+        }
+
+        type Door {
+            doorPosition: DoorPosition @instanceTag
+        }
+
+        type Cabin {
+            doors: [Door]
+        }
+
+        type Query {
+            cabin: Cabin
+        }
+    """)
+
+    expanded_schema, _, field_metadata = instance_tag_utils.expand_instances_in_schema(schema)
+    type_map = expanded_schema.type_map
+
+    assert set(cast(GraphQLObjectType, type_map["Door_Row"]).fields) == {"ROW1", "ROW2"}
+    assert set(cast(GraphQLObjectType, type_map["Door_Side"]).fields) == {"LEFT", "RIGHT"}
+    assert set(cast(GraphQLObjectType, type_map["Door_Height"]).fields) == {"TOP", "BOTTOM"}
+    assert not any("ROW1_" in name or "ROW2_" in name for name in type_map)
+
+    assert field_metadata[("Cabin", "Door")].resolved_names == [
+        "Door.ROW1.LEFT.TOP",
+        "Door.ROW1.LEFT.BOTTOM",
+        "Door.ROW1.RIGHT.TOP",
+        "Door.ROW1.RIGHT.BOTTOM",
+        "Door.ROW2.LEFT.TOP",
+        "Door.ROW2.LEFT.BOTTOM",
+        "Door.ROW2.RIGHT.TOP",
+        "Door.ROW2.RIGHT.BOTTOM",
+    ]
+
+
+def test_expand_instances_with_exclusion_on_flat_enum_instance() -> None:
+    """A directly-tagged enum is a single dimension; excluding a value drops it from the one level type."""
+    schema = build_schema("""
+        directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM
+
+        enum DoorPosition @instanceTag {
+            FRONT_LEFT
+            FRONT_RIGHT
+            REAR_LEFT
+            REAR_RIGHT
+        }
+
+        type Door {
+            position: DoorPosition @instanceTag(exclude: ["FRONT_LEFT"])
+        }
+
+        type Cabin {
+            doors: [Door]
+        }
+
+        type Query {
+            cabin: Cabin
+        }
+    """)
+
+    expanded_schema, _, field_metadata = instance_tag_utils.expand_instances_in_schema(schema)
+    type_map = expanded_schema.type_map
+
+    assert set(cast(GraphQLObjectType, type_map["Door_Position"]).fields) == {"FRONT_RIGHT", "REAR_LEFT", "REAR_RIGHT"}
+
+    assert field_metadata[("Cabin", "Door")].resolved_names == [
+        "Door.FRONT_RIGHT",
+        "Door.REAR_LEFT",
+        "Door.REAR_RIGHT",
+    ]
+
+
 # #########################################################
 # Directive utils
 # #########################################################
@@ -358,6 +527,35 @@ def test_get_directive_arguments(schema_path: list[Path]) -> None:
             assert isinstance(args, dict)
             break
         break
+
+
+def test_get_directive_arguments_parses_instance_tag_exclude_list() -> None:
+    schema = build_schema("""
+    directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM
+
+    enum RowEnum { ROW1 ROW2 }
+    enum SideEnum { LEFT RIGHT }
+
+    type DoorPosition @instanceTag {
+      row: RowEnum!
+      side: SideEnum!
+    }
+
+    type Door {
+      doorPosition: DoorPosition @instanceTag(exclude: [\"ROW1.LEFT\"])
+    }
+
+    type Query {
+      door: Door
+    }
+    """)
+
+    door_type = schema.type_map["Door"]
+    assert isinstance(door_type, GraphQLObjectType)
+
+    args = directive_utils.get_directive_arguments(door_type.fields["doorPosition"], "instanceTag")
+
+    assert args["exclude"] == ["ROW1.LEFT"]
 
 
 def test_has_given_directive(schema_path: list[Path]) -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -420,7 +420,7 @@ def test_expand_instances_with_exclusion_across_multiple_dimensions() -> None:
 def test_expand_instances_multiple_dimensions_share_level_types_without_exclusion() -> None:
     """Without exclusion, every level collapses to a single shared type across all three dimensions."""
     schema = build_schema("""
-        directive @instanceTag on OBJECT | FIELD_DEFINITION
+        directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM
 
         enum RowEnum {
             ROW1

--- a/tests/test_vss_Seat/15_05_2025/schema.graphql
+++ b/tests/test_vss_Seat/15_05_2025/schema.graphql
@@ -4,7 +4,7 @@ directive @range(min: Float, max: Float) on FIELD_DEFINITION
 
                     directive @noDuplicates on FIELD_DEFINITION
 
-                    directive @instanceTag on OBJECT
+                    directive @instanceTag on OBJECT | FIELD_DEFINITION
 
                     directive @metadata(comment: String, vssType: String) on FIELD_DEFINITION | OBJECT
 
@@ -171,7 +171,7 @@ directive @range(min: Float, max: Float) on FIELD_DEFINITION
                       backrest: Backrest
                       headrest: Headrest
                       seating: Seating
-                      instanceTag: ManySeatsInstanceTag
+                      manySeats: ManySeatsInstanceTag @instanceTag
                     }
 
                     """Airbag signals."""

--- a/tests/test_vss_Seat/15_05_2025/schema.graphql
+++ b/tests/test_vss_Seat/15_05_2025/schema.graphql
@@ -4,7 +4,7 @@ directive @range(min: Float, max: Float) on FIELD_DEFINITION
 
                     directive @noDuplicates on FIELD_DEFINITION
 
-                    directive @instanceTag on OBJECT | FIELD_DEFINITION
+                    directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM
 
                     directive @metadata(comment: String, vssType: String) on FIELD_DEFINITION | OBJECT
 

--- a/tests/test_vss_Seat/15_05_2025/schema_with_other_domains.graphql
+++ b/tests/test_vss_Seat/15_05_2025/schema_with_other_domains.graphql
@@ -4,7 +4,7 @@ directive @range(min: Float, max: Float) on FIELD_DEFINITION
 
                     directive @noDuplicates on FIELD_DEFINITION
 
-                    directive @instanceTag on OBJECT | FIELD_DEFINITION
+                    directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM
 
                     directive @metadata(comment: String, vssType: String) on FIELD_DEFINITION | OBJECT
 

--- a/tests/test_vss_Seat/15_05_2025/schema_with_other_domains.graphql
+++ b/tests/test_vss_Seat/15_05_2025/schema_with_other_domains.graphql
@@ -4,7 +4,7 @@ directive @range(min: Float, max: Float) on FIELD_DEFINITION
 
                     directive @noDuplicates on FIELD_DEFINITION
 
-                    directive @instanceTag on OBJECT
+                    directive @instanceTag on OBJECT | FIELD_DEFINITION
 
                     directive @metadata(comment: String, vssType: String) on FIELD_DEFINITION | OBJECT
 
@@ -197,7 +197,7 @@ directive @range(min: Float, max: Float) on FIELD_DEFINITION
                       backrest: Backrest
                       headrest: Headrest
                       seating: Seating
-                      instanceTag: ManySeatsInstanceTag
+                      manySeats: ManySeatsInstanceTag @instanceTag
                     }
 
                     """Airbag signals."""


### PR DESCRIPTION
This PR closes #182 and #184.

Example:

```graphql
directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM

enum RowEnum {
    ROW1
    ROW2
}

enum SideEnum {
    LEFT
    RIGHT
}

type DoorPosition @instanceTag(exclude: ["ROW1.LEFT"]) {
    row: RowEnum!
    side: SideEnum!
}

enum MirrorPosition @instanceTag(exclude: ["CENTER"]) {
    LEFT
    CENTER
    RIGHT
}

type Door {
    doorPosition: DoorPosition @instanceTag(exclude: ["ROW2.RIGHT"])
}

type Mirror {
    position: MirrorPosition @instanceTag(exclude: ["LEFT"])
}

type Cabin {
    doors: [Door]
    mirrors: [Mirror]
}
```

```shell
s2dm compose --schema schema.graphql --expanded-instances --output out.graphql
```

```graphql
directive @instanceTag(exclude: [String!]) on OBJECT | FIELD_DEFINITION | ENUM

enum RowEnum {
  ROW1
  ROW2
}

enum SideEnum {
  LEFT
  RIGHT
}

type Door

type Mirror

type Cabin {
  Door: Door_Row!
  Mirror: Mirror_Position!
}

type Query {
  ping: String
}

type Door_ROW1_Side {
  RIGHT: Door
}

type Door_ROW2_Side {
  LEFT: Door
}

type Door_Row {
  ROW1: Door_ROW1_Side!
  ROW2: Door_ROW2_Side!
}

type Mirror_Position {
  RIGHT: Mirror
}
```