### PR TITLE
feat: add naming case exceptions and update integer mapping in shacl

### DIFF
--- a/src/s2dm/exporters/README.md
+++ b/src/s2dm/exporters/README.md
@@ -316,6 +316,14 @@ instanceTag: COBOL-CASE
 # Transform argument names by context
 argument:
   field: camelCase
+
+# Literal overrides applied before case conversion, regardless of element type
+# or context (type, field, argument, enum value, instance tag). Matching is
+# exact and case-sensitive against the original schema name.
+exceptions:
+  AI: AI
+  VIN: VIN
+  PWFStatus: PWFStatus
 ```
 
 ### Supported Case Formats
@@ -372,7 +380,7 @@ The naming configuration system enforces several validation rules to ensure cons
 
 #### Element Type Validation
 
-- **Valid element types**: Only `type`, `field`, `argument`, `enumValue`, and `instanceTag` are allowed
+- **Valid element types**: Only `type`, `field`, `argument`, `enumValue`, `instanceTag`, and `exceptions` are allowed
 - **Context restrictions**: Some element types cannot have context-specific configurations:
   - `enumValue` and `instanceTag` are contextless and use a single case format
   - `argument` can only have `field` context
@@ -393,6 +401,24 @@ The naming configuration system enforces several validation rules to ensure cons
 
 - **EnumValue-InstanceTag pairing**: If `enumValue` is present in the configuration, `instanceTag` must also be present
 - **InstanceTag preservation**: The literal field name `instanceTag` is never transformed, regardless of naming configuration, to preserve its semantic meaning
+
+### Exceptions
+
+The optional `exceptions` key maps literal names to literal replacements that are
+applied instead of case conversion. This is useful for names that a case converter
+would otherwise mangle, such as acronyms (e.g. `AI`, `VIN` becoming `Ai`, `Vin` under
+PascalCase).
+
+- **Global scope**: exceptions apply to every element type and context (type, field,
+  argument, enum value, instance tag) — there is currently no way to scope an
+  exception to only one of these. If the same literal name needs different
+  treatment depending on where it appears, this is a known limitation.
+- **Exact, case-sensitive matching**: the full name as it appears in the source
+  schema must match a key in `exceptions`; partial/substring matches are not
+  supported.
+- **Applies everywhere `convert_name` is used**: both export-time conversion and
+  `s2dm check constraints` naming validation honor `exceptions`, so an excepted
+  name is treated as compliant in both cases.
 
 ### Notes
 

--- a/src/s2dm/exporters/shacl.py
+++ b/src/s2dm/exporters/shacl.py
@@ -37,7 +37,20 @@ class Namespaces:
 
 
 # Datatype mapping from GraphQL to XSD
-GRAPHQL_SCALAR_TO_XSD = {"Int": "integer", "Float": "float", "String": "string", "Boolean": "boolean", "ID": "string"}
+GRAPHQL_SCALAR_TO_XSD = {
+    "Int": "integer",
+    "Float": "float",
+    "String": "string",
+    "Boolean": "boolean",
+    "ID": "string",
+    "Int8": "byte",
+    "UInt8": "unsignedByte",
+    "Int16": "short",
+    "UInt16": "unsignedShort",
+    "UInt32": "unsignedInt",
+    "Int64": "long",
+    "UInt64": "unsignedLong",
+}
 
 
 def get_xsd_datatype(scalar: GraphQLScalarType) -> URIRef:

--- a/src/s2dm/exporters/utils/naming.py
+++ b/src/s2dm/exporters/utils/naming.py
@@ -45,16 +45,21 @@ TYPE_CONTEXTS = {
 }
 
 
-def convert_name(name: str, target_case: CaseFormat) -> str:
+def convert_name(name: str, target_case: CaseFormat, exceptions: dict[str, str] | None = None) -> str:
     """Convert a name to the specified case format.
 
     Args:
         name: The name to convert
         target_case: The target case format
+        exceptions: Optional mapping of literal names to literal replacements, checked
+            before case conversion. Matching is exact and applies regardless of
+            element type or context (e.g. type, field, argument, enum value).
 
     Returns:
         The converted name
     """
+    if exceptions and name in exceptions:
+        return exceptions[name]
     return str(CASE_CONVERTERS[target_case](name))
 
 
@@ -93,7 +98,7 @@ def apply_naming_to_schema(schema: GraphQLSchema, naming_config: NamingConventio
         if context:
             target_case = get_case_for_element(ElementType.TYPE, context, naming_config)
             if target_case:
-                new_name = convert_name(type_name, target_case)
+                new_name = convert_name(type_name, target_case, naming_config.exceptions)
                 if new_name != type_name:
                     types_to_rename.append((type_name, new_name, type_obj))
 
@@ -131,7 +136,7 @@ def convert_field_names(
     if target_case:
         new_fields = {}
         for old_name, field in type_obj.fields.items():
-            new_name = convert_name(old_name, target_case)
+            new_name = convert_name(old_name, target_case, naming_config.exceptions)
             new_fields[new_name] = field
 
         type_obj.fields.clear()
@@ -144,7 +149,7 @@ def convert_field_names(
                 if arg_target_case:
                     new_args = {}
                     for old_name, arg in field.args.items():
-                        new_name = convert_name(old_name, arg_target_case)
+                        new_name = convert_name(old_name, arg_target_case, naming_config.exceptions)
                         new_args[new_name] = arg
 
                     field.args.clear()
@@ -170,7 +175,7 @@ def convert_enum_values(
 
     new_values = {}
     for old_name, enum_value in type_obj.values.items():
-        new_name = convert_name(old_name, target_case)
+        new_name = convert_name(old_name, target_case, naming_config.exceptions)
         new_values[new_name] = enum_value
 
     type_obj.values.clear()
@@ -196,7 +201,7 @@ def apply_naming_to_instance_values(
     if not target_case:
         return instance_values
 
-    return [convert_name(value, target_case) for value in instance_values]
+    return [convert_name(value, target_case, naming_config.exceptions) for value in instance_values]
 
 
 def load_naming_config(config_path: Path | None) -> NamingConventionConfig | None:

--- a/src/s2dm/exporters/utils/naming_config.py
+++ b/src/s2dm/exporters/utils/naming_config.py
@@ -75,6 +75,7 @@ class NamingConventionConfig(BaseModel):
     argument: ArgumentNamingConfig | None = None
     enum_value: CaseFormat | None = Field(None, alias="enumValue")
     instance_tag: CaseFormat | None = Field(None, alias="instanceTag")
+    exceptions: dict[str, str] | None = None
 
     @model_validator(mode="after")
     def validate_enum_value_requires_instance_tag(self, info: ValidationInfo) -> "NamingConventionConfig":

--- a/src/s2dm/tools/naming_checker.py
+++ b/src/s2dm/tools/naming_checker.py
@@ -21,17 +21,21 @@ from s2dm.exporters.utils.naming_config import (
 _inflect_engine = inflect.engine()
 
 
-def _matches_case_format(name: str, case_format: CaseFormat) -> tuple[bool, str]:
+def _matches_case_format(
+    name: str, case_format: CaseFormat, exceptions: dict[str, str] | None = None
+) -> tuple[bool, str]:
     """Check if a name matches the specified case format.
 
     Args:
         name: The name to check
         case_format: The expected case format
+        exceptions: Optional mapping of literal names to literal replacements that are
+            considered compliant as-is, checked before case conversion.
 
     Returns:
         True if the name matches the case format, False otherwise
     """
-    converted_name = convert_name(name, case_format)
+    converted_name = convert_name(name, case_format, exceptions)
     matches = name == converted_name
 
     return matches, converted_name
@@ -81,7 +85,7 @@ def check_naming_conventions(
 
         expected_case = get_case_for_element(ElementType.TYPE, context, config)
         if expected_case:
-            matches, suggestion = _matches_case_format(type_name, expected_case)
+            matches, suggestion = _matches_case_format(type_name, expected_case, config.exceptions)
             if not matches:
                 type_errors.append(
                     f"[naming] Type '{type_name}' should be {expected_case.value} (suggestion: '{suggestion}')"
@@ -94,7 +98,7 @@ def check_naming_conventions(
             expected_case = get_case_for_element(enum_element_type, None, config)
             if expected_case:
                 for value_name in object_type.values:
-                    matches, suggestion = _matches_case_format(value_name, expected_case)
+                    matches, suggestion = _matches_case_format(value_name, expected_case, config.exceptions)
                     if not matches:
                         enum_value_errors.append(
                             f"[naming] Enum value '{object_type.name}.{value_name}' should be {expected_case.value} "
@@ -111,7 +115,7 @@ def check_naming_conventions(
 
             for field_name, field in object_type.fields.items():
                 if field_case:
-                    matches, suggestion = _matches_case_format(field_name, field_case)
+                    matches, suggestion = _matches_case_format(field_name, field_case, config.exceptions)
                     if not matches:
                         field_errors.append(
                             f"[naming] Field '{object_type.name}.{field_name}' should be {field_case.value} "
@@ -136,7 +140,7 @@ def check_naming_conventions(
 
                 if argument_case and field.args:
                     for arg_name in field.args:
-                        matches, suggestion = _matches_case_format(arg_name, argument_case)
+                        matches, suggestion = _matches_case_format(arg_name, argument_case, config.exceptions)
                         if not matches:
                             argument_errors.append(
                                 f"[naming] Argument '{object_type.name}.{field_name}({arg_name})' should be "

--- a/tests/test_naming_convention.py
+++ b/tests/test_naming_convention.py
@@ -1,6 +1,13 @@
+from pathlib import Path
+
 from graphql import build_schema
 
-from s2dm.exporters.utils.naming_config import CaseFormat, NamingConventionConfig, ValidationMode
+from s2dm.exporters.utils.naming_config import (
+    CaseFormat,
+    NamingConventionConfig,
+    ValidationMode,
+    load_naming_convention_config,
+)
 from s2dm.tools.naming_checker import check_naming_conventions
 
 
@@ -21,6 +28,28 @@ def test_type_name_violations() -> None:
     errors = check_naming_conventions(schema, config)
 
     assert len(errors) == 2
+
+
+def test_type_name_exception_is_not_a_violation() -> None:
+    """A type name listed in exceptions is treated as compliant, even if it wouldn't match the target case."""
+    schema = build_schema("""
+        type AI {
+            field: String
+        }
+
+        type another_type {
+            field: String
+        }
+    """)
+
+    config = NamingConventionConfig.model_validate(
+        {"type": {"object": CaseFormat.PASCAL_CASE}, "exceptions": {"AI": "AI"}},
+        context={"mode": ValidationMode.CHECK},
+    )
+    errors = check_naming_conventions(schema, config)
+
+    assert len(errors) == 1
+    assert "another_type" in errors[0]
 
 
 def test_interface_name_violations() -> None:
@@ -161,3 +190,16 @@ def test_multiple_violation_types() -> None:
     errors = check_naming_conventions(schema, config)
 
     assert len(errors) == 7
+
+
+def test_load_naming_convention_config_parses_exceptions(tmp_path: Path) -> None:
+    """load_naming_convention_config parses the top-level exceptions key from YAML."""
+    config_path = tmp_path / "naming.yaml"
+    config_path.write_text(
+        "type:\n" "  object: PascalCase\n" "exceptions:\n" "  AI: AI\n" "  VIN: VIN\n" "  PwfStatus: PWFStatus\n"
+    )
+
+    config = load_naming_convention_config(config_path)
+
+    assert config is not None
+    assert config.exceptions == {"AI": "AI", "VIN": "VIN", "PwfStatus": "PWFStatus"}

--- a/tests/test_naming_utils.py
+++ b/tests/test_naming_utils.py
@@ -18,6 +18,7 @@ from graphql import (
 from s2dm.exporters.shacl import translate_to_shacl
 from s2dm.exporters.utils.instance_tag import expand_instances_in_schema
 from s2dm.exporters.utils.naming import (
+    apply_naming_to_instance_values,
     apply_naming_to_schema,
     convert_enum_values,
     convert_field_names,
@@ -61,6 +62,26 @@ class TestConvertName:
         """Test conversion with empty string input."""
         result = convert_name("", CaseFormat.CAMEL_CASE)
         assert result == ""
+
+    def test_convert_name_exception_overrides_case_conversion(self) -> None:
+        """Test that an exact match in exceptions bypasses case conversion."""
+        result = convert_name("AI", CaseFormat.PASCAL_CASE, {"AI": "AI"})
+        assert result == "AI"
+
+    def test_convert_name_exception_supports_arbitrary_mapping(self) -> None:
+        """Test that exceptions can map a name to an arbitrary literal, not just itself."""
+        result = convert_name("PwfStatus", CaseFormat.PASCAL_CASE, {"PwfStatus": "PWFStatus"})
+        assert result == "PWFStatus"
+
+    def test_convert_name_non_matching_exception_falls_back_to_case_conversion(self) -> None:
+        """Test that names not present in exceptions are converted normally."""
+        result = convert_name("hello_world", CaseFormat.PASCAL_CASE, {"AI": "AI"})
+        assert result == "HelloWorld"
+
+    def test_convert_name_none_exceptions_falls_back_to_case_conversion(self) -> None:
+        """Test that a None exceptions mapping behaves like no exceptions provided."""
+        result = convert_name("hello_world", CaseFormat.PASCAL_CASE, None)
+        assert result == "HelloWorld"
 
 
 class TestGetCaseForElement:
@@ -190,6 +211,40 @@ class TestApplyNamingToSchema:
         test_object_type = original_schema.type_map["TestObject"]
         assert isinstance(test_object_type, GraphQLObjectType)
         assert "TestField" in test_object_type.fields
+
+    def test_apply_naming_exceptions_preserve_acronym_names(self) -> None:
+        """Test that names listed in exceptions bypass case conversion for types, fields, and enum values."""
+        enum_type = GraphQLEnumType(name="pwf_status", values={"ai_vin": GraphQLEnumValue("ai_vin")})
+        object_type = GraphQLObjectType(name="vin_info", fields={"ai_score": GraphQLField(GraphQLString)})
+
+        query_type = GraphQLObjectType(name="Query", fields={"test": GraphQLField(object_type)})
+        schema = GraphQLSchema(query=query_type, types=[object_type, enum_type])
+
+        naming_config = NamingConventionConfig(
+            type=TypeNamingConfig(object=CaseFormat.PASCAL_CASE, enum=CaseFormat.PASCAL_CASE),
+            field=FieldNamingConfig(object=CaseFormat.PASCAL_CASE),
+            enum_value=CaseFormat.PASCAL_CASE,
+            instance_tag=CaseFormat.PASCAL_CASE,
+            exceptions={
+                "vin_info": "VINInfo",
+                "pwf_status": "PWFStatus",
+                "ai_score": "AIScore",
+                "ai_vin": "AIVIN",
+            },
+        )
+
+        apply_naming_to_schema(schema, naming_config)
+
+        assert "VINInfo" in schema.type_map
+        assert "PWFStatus" in schema.type_map
+
+        vin_info_type = schema.type_map["VINInfo"]
+        assert isinstance(vin_info_type, GraphQLObjectType)
+        assert "AIScore" in vin_info_type.fields
+
+        pwf_status_type = schema.type_map["PWFStatus"]
+        assert isinstance(pwf_status_type, GraphQLEnumType)
+        assert "AIVIN" in pwf_status_type.values
 
     def test_apply_naming_routes_instancetag_enums_to_instancetag_case(self) -> None:
         """Enums inside @instanceTag types get instanceTag case; other enums get enumValue case."""
@@ -461,6 +516,30 @@ class TestInstanceTagConversion:
         # DoorPosition has row: RowEnum (ROW1, ROW2) and side: SideEnum (DRIVERSIDE, PASSENGERSIDE)
         # instanceTag: PascalCase -> Row1, Row2, Driverside, Passengerside
         assert sh_in_values == {"Row1", "Row2", "Driverside", "Passengerside"}
+
+
+class TestApplyNamingToInstanceValues:
+    """Test applying naming conversion (including exceptions) to instance tag values."""
+
+    def test_apply_naming_to_instance_values_converts_case(self) -> None:
+        """Test that instance values are converted using the configured instanceTag case."""
+        naming_config = NamingConventionConfig(instance_tag=CaseFormat.PASCAL_CASE)
+        result = apply_naming_to_instance_values(["front_left", "front_right"], naming_config)
+        assert result == ["FrontLeft", "FrontRight"]
+
+    def test_apply_naming_to_instance_values_honors_exceptions(self) -> None:
+        """Test that exceptions bypass case conversion for instance tag values."""
+        naming_config = NamingConventionConfig(
+            instance_tag=CaseFormat.PASCAL_CASE,
+            exceptions={"ai_vin": "AIVIN"},
+        )
+        result = apply_naming_to_instance_values(["ai_vin", "front_right"], naming_config)
+        assert result == ["AIVIN", "FrontRight"]
+
+    def test_apply_naming_to_instance_values_no_config_returns_unchanged(self) -> None:
+        """Test that a None naming_config leaves instance values unchanged."""
+        result = apply_naming_to_instance_values(["front_left"], None)
+        assert result == ["front_left"]
 
 
 if __name__ == "__main__":

--- a/tests/test_shacl.py
+++ b/tests/test_shacl.py
@@ -1,0 +1,106 @@
+import pytest
+from graphql import GraphQLScalarType, GraphQLSchema, build_schema
+from rdflib import XSD, Literal
+from rdflib.namespace import SH
+
+from s2dm.exporters.shacl import GRAPHQL_SCALAR_TO_XSD, get_xsd_datatype, translate_to_shacl
+from s2dm.exporters.utils.annotated_schema import AnnotatedSchema
+
+
+class TestGetXsdDatatype:
+    """Test the GraphQL scalar to XSD datatype mapping."""
+
+    @pytest.mark.parametrize(
+        "scalar_name,expected_xsd_fragment",
+        [
+            ("Int", "integer"),
+            ("Float", "float"),
+            ("String", "string"),
+            ("Boolean", "boolean"),
+            ("ID", "string"),
+            ("Int8", "byte"),
+            ("UInt8", "unsignedByte"),
+            ("Int16", "short"),
+            ("UInt16", "unsignedShort"),
+            ("UInt32", "unsignedInt"),
+            ("Int64", "long"),
+            ("UInt64", "unsignedLong"),
+        ],
+    )
+    def test_known_scalars_map_to_expected_xsd_type(self, scalar_name: str, expected_xsd_fragment: str) -> None:
+        """Each known GraphQL scalar (built-in and custom integer widths) maps to the correct XSD datatype."""
+        scalar = GraphQLScalarType(name=scalar_name)
+        assert get_xsd_datatype(scalar) == XSD[expected_xsd_fragment]
+
+    def test_unknown_scalar_falls_back_to_string(self) -> None:
+        """A scalar not present in the mapping falls back to xsd:string."""
+        scalar = GraphQLScalarType(name="SomeCustomScalar")
+        assert get_xsd_datatype(scalar) == XSD.string
+
+    def test_custom_integer_scalars_are_not_string(self) -> None:
+        """Regression guard: custom integer-width scalars must not fall back to xsd:string."""
+        for scalar_name in ("Int8", "UInt8", "Int16", "UInt16", "UInt32", "Int64", "UInt64"):
+            assert GRAPHQL_SCALAR_TO_XSD[scalar_name] != "string"
+
+
+class TestTranslateToShaclScalarDatatypes:
+    """Integration test: translate_to_shacl emits the correct sh:datatype for custom integer scalars."""
+
+    def _build_annotated_schema(self) -> GraphQLSchema:
+        return build_schema("""
+            scalar Int8
+            scalar UInt8
+            scalar Int16
+            scalar UInt16
+            scalar UInt32
+            scalar Int64
+            scalar UInt64
+
+            type Vehicle {
+                gear: Int8
+                brightness: UInt8
+                angle: Int16
+                position: UInt16
+                odometer: UInt32
+                mileage: Int64
+                totalDistance: UInt64
+            }
+
+            type Query {
+                vehicle: Vehicle
+            }
+        """)
+
+    def test_custom_scalar_fields_emit_correct_sh_datatype(self) -> None:
+        schema = self._build_annotated_schema()
+        annotated_schema = AnnotatedSchema(schema=schema)
+
+        graph = translate_to_shacl(
+            annotated_schema,
+            "http://ex/shapes#",
+            "shapes",
+            "http://ex/model#",
+            "model",
+        )
+
+        expected_field_to_datatype = {
+            "gear": XSD.byte,
+            "brightness": XSD.unsignedByte,
+            "angle": XSD.short,
+            "position": XSD.unsignedShort,
+            "odometer": XSD.unsignedInt,
+            "mileage": XSD.long,
+            "totalDistance": XSD.unsignedLong,
+        }
+
+        for field_name, expected_datatype in expected_field_to_datatype.items():
+            datatypes = {
+                dtype
+                for property_node in graph.subjects(SH.name, Literal(field_name))
+                for dtype in graph.objects(property_node, SH.datatype)
+            }
+            assert datatypes == {expected_datatype}, f"Field '{field_name}' has datatypes {datatypes}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
1. **Naming exceptions** — the `--naming-config` YAML now accepts a global
   `exceptions` map of literal name → literal replacement, checked before case
   conversion. This lets SMEs preserve names like acronyms (`AI`, `VIN`,
   `PWFStatus`) that would otherwise be mangled by case conversion.
2. **SHACL integer scalar mapping** — `Int8`, `UInt8`, `Int16`, `UInt16`,
   `UInt32`, `Int64`, and `UInt64` custom scalars now map to their precise XSD
   facet types (`xsd:byte`, `xsd:unsignedByte`, `xsd:short`, `xsd:unsignedShort`,
   `xsd:unsignedInt`, `xsd:long`, `xsd:unsignedLong`) instead of falling back to
   `xsd:string`.

## Changes

- `src/s2dm/exporters/utils/naming_config.py`: add `exceptions: dict[str, str] | None`
  field to `NamingConventionConfig`.
- `src/s2dm/exporters/utils/naming.py`: add `exceptions` parameter to
  `convert_name()`, checked before case conversion; threaded through all
  call sites (`apply_naming_to_schema`, `convert_field_names`,
  `convert_enum_values`, `apply_naming_to_instance_values`).
- `src/s2dm/tools/naming_checker.py`: thread `config.exceptions` through
  `_matches_case_format()` so `s2dm check constraints` treats excepted names
  as compliant, keeping conversion and validation behavior consistent.
- `src/s2dm/exporters/shacl.py`: extend `GRAPHQL_SCALAR_TO_XSD` with precise
  mappings for the 7 custom integer scalars.
- `src/s2dm/exporters/README.md`: document the new `exceptions` naming-config
  key (scope/limitations, exact case-sensitive matching, applies to both
  convert and check modes).
- Tests: extend `tests/test_naming_utils.py` and `tests/test_naming_convention.py`
  with exceptions coverage (including YAML parsing), and add
  `tests/test_shacl.py` covering all 7 scalar-to-XSD mappings.

## Notes

- `exceptions` matching is exact and applies globally (not scoped per element
  type); this is documented as a known limitation.
- Exceptions apply consistently in both export/conversion and
  `check constraints` validation paths, since both flow through `convert_name()`.